### PR TITLE
#6 RadeonでwglDeleteContextがハングする問題の改善

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendor/aviutl_exedit_sdk"]
+	path = vendor/aviutl_exedit_sdk
+	url = https://github.com/ePi5131/aviutl_exedit_sdk.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,9 @@ set(LUA_LIBRARY_DIR ${PROJECT_SOURCE_DIR}/vendor/lua)
 set(GLAD_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/vendor/glad/include)
 set(GLAD_SOURCE_DIR ${PROJECT_SOURCE_DIR}/vendor/glad/src)
 
+# aviutl_exedit_sdk
+set(AVIUTL_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/vendor/aviutl_exedit_sdk)
+
 # デバッグに使用するAviUtlがあるディレクトリ
 set(AVIUTL_DIR ${PROJECT_SOURCE_DIR}/bin/aviutl)
 
@@ -44,6 +47,7 @@ target_include_directories(GLShaderKit
     PRIVATE
         ${LUA_INCLUDE_DIR}
         ${GLAD_INCLUDE_DIR}
+        ${AVIUTL_INCLUDE_DIR}
 )
 target_link_directories(GLShaderKit PRIVATE ${LUA_LIBRARY_DIR})
 target_link_libraries(GLShaderKit
@@ -61,19 +65,25 @@ target_compile_definitions(GLShaderKit
         GL_SHADER_KIT_VERSION="${PROJECT_VERSION}"
         NOMINMAX
 )
+set_target_properties(GLShaderKit PROPERTIES SUFFIX .auf)
 
 # 検証用の AviUtl に配置
 add_custom_target(debug_deploy ALL
     ${CMAKE_COMMAND} -E make_directory ${AVIUTL_DIR}/script/GLShaderKit
     COMMAND ${CMAKE_COMMAND} -E copy
-        $<TARGET_FILE:GLShaderKit>
-        ${PROJECT_SOURCE_DIR}/src/GLShaderKit.ini
         ${PROJECT_SOURCE_DIR}/example/GLShaderKit_info.obj
         ${PROJECT_SOURCE_DIR}/example/GLShaderKit_draw.obj
         ${PROJECT_SOURCE_DIR}/example/GLShaderKit_drawPoints.obj
         ${PROJECT_SOURCE_DIR}/example/GLShaderKit_effect.anm
         ${PROJECT_SOURCE_DIR}/example/GLShaderKit_effectInstanced.anm
         ${AVIUTL_DIR}/script/GLShaderKit
+    COMMAND ${CMAKE_COMMAND} -E copy
+        $<TARGET_FILE:GLShaderKit>
+        ${PROJECT_SOURCE_DIR}/src/GLShaderKit.ini
+        ${AVIUTL_DIR}/plugins
+    COMMAND ${CMAKE_COMMAND} -E copy
+        ${PROJECT_SOURCE_DIR}/src/GLShaderKit.lua
+        ${AVIUTL_DIR}
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
     DEPENDS GLShaderKit
     COMMENT "debug_deploy -> ${AVIUTL_DIR}"

--- a/src/GLShaderKit.lua
+++ b/src/GLShaderKit.lua
@@ -1,0 +1,1 @@
+return package.loadlib("GLShaderKit.auf","luaopen_GLShaderKit")()


### PR DESCRIPTION
Radeon で `wglDeleteContext` がハングする件の修正 (#6)

`.dll` を `.auf` にすることでなぜかハングしなくなった。
理由は不明だが改善はされているのでこれで行きたい。

今までは以下のファイルが必要だったが、
- `GLShaderKit.dll`
- `GLShaderKit.ini`

今度からは以下のファイルが必要になる。
- `GLShaderKit.auf`
- `GLShaderKit.ini`
- `GLShaderKit.lua`

`GLShaderKit.lua` はスクリプトから `GLShaderKit.auf` に実装された Lua 用モジュールを読み込むためのローダー。

以上のファイルを適切な場所に配置すれば、 GLShaderKit を使用した既存スクリプトの修正は不要である。