### PR TITLE
#6 RadeonでwglDeleteContextがハングする問題をdllのまま改善

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "vendor/aviutl_exedit_sdk"]
-	path = vendor/aviutl_exedit_sdk
-	url = https://github.com/ePi5131/aviutl_exedit_sdk.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,6 @@ add_custom_target(package
     COMMAND 7z a publish/${PROJECT_NAME}_v${PROJECT_VERSION}.zip
         $<TARGET_FILE:GLShaderKit>
         ${PROJECT_SOURCE_DIR}/src/GLShaderKit.ini
-        ${PROJECT_SOURCE_DIR}/src/GLShaderKit.lua
         README.md
         LICENSE
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,9 +18,6 @@ set(LUA_LIBRARY_DIR ${PROJECT_SOURCE_DIR}/vendor/lua)
 set(GLAD_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/vendor/glad/include)
 set(GLAD_SOURCE_DIR ${PROJECT_SOURCE_DIR}/vendor/glad/src)
 
-# aviutl_exedit_sdk
-set(AVIUTL_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/vendor/aviutl_exedit_sdk)
-
 # デバッグに使用するAviUtlがあるディレクトリ
 set(AVIUTL_DIR ${PROJECT_SOURCE_DIR}/bin/aviutl)
 
@@ -47,7 +44,6 @@ target_include_directories(GLShaderKit
     PRIVATE
         ${LUA_INCLUDE_DIR}
         ${GLAD_INCLUDE_DIR}
-        ${AVIUTL_INCLUDE_DIR}
 )
 target_link_directories(GLShaderKit PRIVATE ${LUA_LIBRARY_DIR})
 target_link_libraries(GLShaderKit
@@ -65,25 +61,19 @@ target_compile_definitions(GLShaderKit
         GL_SHADER_KIT_VERSION="${PROJECT_VERSION}"
         NOMINMAX
 )
-set_target_properties(GLShaderKit PROPERTIES SUFFIX .auf)
 
 # 検証用の AviUtl に配置
 add_custom_target(debug_deploy ALL
     ${CMAKE_COMMAND} -E make_directory ${AVIUTL_DIR}/script/GLShaderKit
     COMMAND ${CMAKE_COMMAND} -E copy
+        $<TARGET_FILE:GLShaderKit>
+        ${PROJECT_SOURCE_DIR}/src/GLShaderKit.ini
         ${PROJECT_SOURCE_DIR}/example/GLShaderKit_info.obj
         ${PROJECT_SOURCE_DIR}/example/GLShaderKit_draw.obj
         ${PROJECT_SOURCE_DIR}/example/GLShaderKit_drawPoints.obj
         ${PROJECT_SOURCE_DIR}/example/GLShaderKit_effect.anm
         ${PROJECT_SOURCE_DIR}/example/GLShaderKit_effectInstanced.anm
         ${AVIUTL_DIR}/script/GLShaderKit
-    COMMAND ${CMAKE_COMMAND} -E copy
-        $<TARGET_FILE:GLShaderKit>
-        ${PROJECT_SOURCE_DIR}/src/GLShaderKit.ini
-        ${AVIUTL_DIR}/plugins
-    COMMAND ${CMAKE_COMMAND} -E copy
-        ${PROJECT_SOURCE_DIR}/src/GLShaderKit.lua
-        ${AVIUTL_DIR}
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
     DEPENDS GLShaderKit
     COMMENT "debug_deploy -> ${AVIUTL_DIR}"

--- a/src/GLShaderKit.lua
+++ b/src/GLShaderKit.lua
@@ -1,1 +1,0 @@
-return package.loadlib("GLShaderKit.auf","luaopen_GLShaderKit")()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,6 @@
 
 #include <glad/gl.h>
 #include <lua.hpp>
-#include <aviutl.hpp>
 
 #include "gl_context.hpp"
 #include "config.hpp"
@@ -17,6 +16,8 @@
 #ifndef GL_SHADER_KIT_VERSION
 #   define GL_SHADER_KIT_VERSION "0.0.0"
 #endif
+
+HINSTANCE g_hinst = nullptr;
 
 GLenum GetGLDrawMode(const std::string& modeStr) {
     static const std::unordered_map<std::string, GLenum> modeMap = {
@@ -212,18 +213,12 @@ static const luaL_Reg kLibFunctions[] = {
 
 // Luaモジュールとしてロードされたときの処理
 GL_SHADER_KIT_API int luaopen_GLShaderKit(lua_State* L) {
-    luaL_register(L, "GLShaderKit", kLibFunctions);
-    return 1;
-}
-
-// フィルタプラグイン初期化処理
-BOOL func_init(AviUtl::FilterPlugin* fp) {
     auto& context = glshaderkit::GLContext::Instance();
     try {
         glshaderkit::Config config;
         // 設定ファイルが見つかれば読み込む
         char dllPath[MAX_PATH];
-        if (GetModuleFileNameA(fp->dll_hinst, dllPath, MAX_PATH)) {
+        if (GetModuleFileNameA(g_hinst, dllPath, MAX_PATH)) {
             std::filesystem::path configPath(dllPath);
             configPath.replace_extension(".ini");
             if (std::filesystem::exists(configPath)) {
@@ -243,30 +238,23 @@ BOOL func_init(AviUtl::FilterPlugin* fp) {
         context.Release();
     }
 
-    return TRUE;
+    luaL_register(L, "GLShaderKit", kLibFunctions);
+    return 1;
 }
 
-// フィルタプラグイン終了処理
-BOOL func_exit(AviUtl::FilterPlugin* fp) {
-    glshaderkit::GLContext::Instance().Release();
+// DLLエントリーポイント
+BOOL APIENTRY DllMain(HINSTANCE hinst, DWORD reason, LPVOID reserved) {
+    switch (reason) {
+    case DLL_PROCESS_ATTACH:
+        g_hinst = hinst;
+        break;
+    case DLL_PROCESS_DETACH:
+        glshaderkit::GLContext::Instance().Release();
+        break;
+    case DLL_THREAD_ATTACH:
+        break;
+    case DLL_THREAD_DETACH:
+        break;
+    }
     return TRUE;
-}
-
-using AviUtl::detail::FilterPluginFlag;
-
-AviUtl::FilterPluginDLL filter_src = {
-    .flag = FilterPluginFlag::AlwaysActive
-        | FilterPluginFlag::PriorityLowest
-        | FilterPluginFlag::ExInformation
-        | FilterPluginFlag::DispFilter
-        | FilterPluginFlag::NoConfig
-        ,
-    .name = "GLShaderKit",
-    .func_init = func_init,
-    .func_exit = func_exit,
-    .information = "GLShaderKit v" GL_SHADER_KIT_VERSION " by karoterra",
-};
-
-GL_SHADER_KIT_API AviUtl::FilterPluginDLL* GetFilterTable(void) {
-    return &filter_src;
 }


### PR DESCRIPTION
RadeonでwglDeleteContextがハングする問題 #6 を PR #7 で一度修正したが、その後Luaモジュール本体を auf にしなくても dll のまま修正できることが分かったため、該当するコミットを取り消して再修正した。