### PR TITLE
#9 テクスチャデータアップロード時に完了を待つ処理を追加

### DIFF
--- a/src/gl_texture.cpp
+++ b/src/gl_texture.cpp
@@ -40,6 +40,14 @@ void GLTexture::Initialize(const void* data) {
     glTextureParameteri(texture_, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     glTextureParameteri(texture_, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTextureParameteri(texture_, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+    // GPUへのアップロード完了待ち
+    GLsync sync = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
+    GLenum waitResult = GL_UNSIGNALED;
+    while (waitResult != GL_ALREADY_SIGNALED && waitResult != GL_CONDITION_SATISFIED) {
+        waitResult = glClientWaitSync(sync, GL_SYNC_FLUSH_COMMANDS_BIT, 1000000000);
+    }
+    glDeleteSync(sync);
 }
 
 void GLTexture::Release() {


### PR DESCRIPTION
複数のテクスチャを使用する際に意図したテクスチャにならないことがある問題の対策 (#9)
同期オブジェクト `glFenceSync` でGPUへのテクスチャデータ転送完了を待つようにした。