### PR TITLE
#1 ユニフォーム変数設定用の関数 setUInt, setMatrix の追加

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,9 @@ add_custom_target(debug_deploy ALL
         ${PROJECT_SOURCE_DIR}/example/GLShaderKit_multiTexture_img0.png
         ${PROJECT_SOURCE_DIR}/example/GLShaderKit_multiTexture_img1.png
         ${PROJECT_SOURCE_DIR}/example/GLShaderKit_multiTexture_img2.png
+        ${PROJECT_SOURCE_DIR}/example/GLShaderKit_uniform.obj
+        ${PROJECT_SOURCE_DIR}/example/GLShaderKit_uniform.frag
+        ${PROJECT_SOURCE_DIR}/example/GLShaderKit_uniform.vert
         ${AVIUTL_DIR}/script/GLShaderKit
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
     DEPENDS GLShaderKit

--- a/example/GLShaderKit_uniform.frag
+++ b/example/GLShaderKit_uniform.frag
@@ -26,6 +26,17 @@ uniform uvec2 ui2;
 uniform uvec3 ui3;
 uniform uvec4 ui4;
 
+uniform mat2 m2;
+uniform mat2 m2t;
+uniform mat3 m3;
+uniform mat4 m4;
+uniform mat2x3 m2x3;
+uniform mat3x2 m3x2;
+uniform mat2x4 m2x4;
+uniform mat4x2 m4x2;
+uniform mat3x4 m3x4;
+uniform mat4x3 m4x3;
+
 const vec3 BLACK = vec3(0.0, 0.0, 0.0);
 const vec3 WHITE = vec3(1.0, 1.0, 1.0);
 const vec2 SQUARE_SIZE = vec2(0.1, 0.1);
@@ -115,6 +126,71 @@ void main() {
     color = mix(ui4.xyz / 255.0, color, step(0.0, sdBox(gridXY(p, vec2(3.0, 4.0)), SQUARE_SIZE)));
     // グリッド (4, 4) ui4.w
     color = mix(vec3(ui4.w) / 255.0, color, step(0.0, sdBox(gridXY(p, vec2(4.0, 4.0)), SQUARE_SIZE)));
+
+    // グリッド (0, 5) m2
+    color = mix(vec3(m2[0], 0.0), color, step(0.0, sdBox(gridXY(p, vec2(0.0, 5.0)), SQUARE_SIZE)));
+    // グリッド (1, 5) m2
+    color = mix(vec3(m2[1], 0.0), color, step(0.0, sdBox(gridXY(p, vec2(1.0, 5.0)), SQUARE_SIZE)));
+    // グリッド (2, 5) m2t
+    color = mix(vec3(m2t[0], 0.0), color, step(0.0, sdBox(gridXY(p, vec2(2.0, 5.0)), SQUARE_SIZE)));
+    // グリッド (3, 5) m2t
+    color = mix(vec3(m2t[1], 0.0), color, step(0.0, sdBox(gridXY(p, vec2(3.0, 5.0)), SQUARE_SIZE)));
+
+    // グリッド (0, 6) m3
+    color = mix(m3[0], color, step(0.0, sdBox(gridXY(p, vec2(0.0, 6.0)), SQUARE_SIZE)));
+    // グリッド (1, 6) m3
+    color = mix(m3[1], color, step(0.0, sdBox(gridXY(p, vec2(1.0, 6.0)), SQUARE_SIZE)));
+    // グリッド (2, 6) m3
+    color = mix(m3[2], color, step(0.0, sdBox(gridXY(p, vec2(2.0, 6.0)), SQUARE_SIZE)));
+
+    // グリッド (0, 7) m4
+    color = mix(vec3(m4[0].x, m4[0].y, m4[0].z), color, step(0.0, sdBox(gridXY(p, vec2(0.0, 7.0)), SQUARE_SIZE)));
+    // グリッド (1, 7) m4
+    color = mix(vec3(m4[0].w, m4[1].x, m4[1].y), color, step(0.0, sdBox(gridXY(p, vec2(1.0, 7.0)), SQUARE_SIZE)));
+    // グリッド (2, 7) m4
+    color = mix(vec3(m4[1].z, m4[1].w, m4[2].x), color, step(0.0, sdBox(gridXY(p, vec2(2.0, 7.0)), SQUARE_SIZE)));
+    // グリッド (3, 7) m4
+    color = mix(vec3(m4[2].y, m4[2].z, m4[2].w), color, step(0.0, sdBox(gridXY(p, vec2(3.0, 7.0)), SQUARE_SIZE)));
+    // グリッド (4, 7) m4
+    color = mix(vec3(m4[3].x, m4[3].y, m4[3].z), color, step(0.0, sdBox(gridXY(p, vec2(4.0, 7.0)), SQUARE_SIZE)));
+
+    // グリッド (0, 8) m2x3
+    color = mix(m2x3[0].xyz, color, step(0.0, sdBox(gridXY(p, vec2(0.0, 8.0)), SQUARE_SIZE)));
+    // グリッド (1, 8) m2x3
+    color = mix(m2x3[1].xyz, color, step(0.0, sdBox(gridXY(p, vec2(1.0, 8.0)), SQUARE_SIZE)));
+    // グリッド (2, 8) m3x2
+    color = mix(vec3(m3x2[0].xy, m3x2[1].x), color, step(0.0, sdBox(gridXY(p, vec2(2.0, 8.0)), SQUARE_SIZE)));
+    // グリッド (3, 8) m3x2
+    color = mix(vec3(m3x2[1].y, m3x2[2].xy), color, step(0.0, sdBox(gridXY(p, vec2(3.0, 8.0)), SQUARE_SIZE)));
+
+    // グリッド (0, 9) m2x4
+    color = mix(vec3(m2x4[0].x, m2x4[0].y, m2x4[0].z), color, step(0.0, sdBox(gridXY(p, vec2(0.0, 9.0)), SQUARE_SIZE)));
+    // グリッド (1, 9) m2x4
+    color = mix(vec3(m2x4[0].w, m2x4[1].x, m2x4[1].y), color, step(0.0, sdBox(gridXY(p, vec2(1.0, 9.0)), SQUARE_SIZE)));
+    // グリッド (2, 9) m2x4, m4x2
+    color = mix(vec3(m2x4[1].z, m2x4[1].w, m4x2[0].x), color, step(0.0, sdBox(gridXY(p, vec2(2.0, 9.0)), SQUARE_SIZE)));
+    // グリッド (3, 9) m4x2
+    color = mix(vec3(m4x2[0].y, m4x2[1].x, m4x2[1].y), color, step(0.0, sdBox(gridXY(p, vec2(3.0, 9.0)), SQUARE_SIZE)));
+    // グリッド (4, 9) m4x2
+    color = mix(vec3(m4x2[2].x, m4x2[2].y, m4x2[3].x), color, step(0.0, sdBox(gridXY(p, vec2(4.0, 9.0)), SQUARE_SIZE)));
+
+    // グリッド (5, 0) m3x4
+    color = mix(vec3(m3x4[0].x, m3x4[0].y, m3x4[0].z), color, step(0.0, sdBox(gridXY(p, vec2(5.0, 0.0)), SQUARE_SIZE)));
+    // グリッド (6, 0) m3x4
+    color = mix(vec3(m3x4[0].w, m3x4[1].x, m3x4[1].y), color, step(0.0, sdBox(gridXY(p, vec2(6.0, 0.0)), SQUARE_SIZE)));
+    // グリッド (7, 0) m3x4
+    color = mix(vec3(m3x4[1].z, m3x4[1].w, m3x4[2].x), color, step(0.0, sdBox(gridXY(p, vec2(7.0, 0.0)), SQUARE_SIZE)));
+    // グリッド (8, 0) m3x4
+    color = mix(vec3(m3x4[2].y, m3x4[2].z, m3x4[2].w), color, step(0.0, sdBox(gridXY(p, vec2(8.0, 0.0)), SQUARE_SIZE)));
+
+    // グリッド (5, 1) m4x3
+    color = mix(m4x3[0].xyz, color, step(0.0, sdBox(gridXY(p, vec2(5.0, 1.0)), SQUARE_SIZE)));
+    // グリッド (6, 1) m4x3
+    color = mix(m4x3[1].xyz, color, step(0.0, sdBox(gridXY(p, vec2(6.0, 1.0)), SQUARE_SIZE)));
+    // グリッド (7, 1) m4x3
+    color = mix(m4x3[2].xyz, color, step(0.0, sdBox(gridXY(p, vec2(7.0, 1.0)), SQUARE_SIZE)));
+    // グリッド (8, 1) m4x3
+    color = mix(m4x3[3].xyz, color, step(0.0, sdBox(gridXY(p, vec2(8.0, 1.0)), SQUARE_SIZE)));
 
     // グリッド (10x10)
     color = mix(vec3(0.5, 0.5, 0.5), color, step(0.0, sdHLine(fract(p * 5.0), 0.05)));

--- a/example/GLShaderKit_uniform.frag
+++ b/example/GLShaderKit_uniform.frag
@@ -1,0 +1,124 @@
+#version 460 core
+
+in vec2 TexCoord;
+
+layout(location = 0) out vec4 FragColor;
+
+uniform vec2 resolution;
+uniform float time;
+uniform float totalTime;
+uniform int frame;
+uniform int totalFrame;
+uniform vec4 track;
+
+uniform float f1;
+uniform vec2 f2;
+uniform vec3 f3;
+uniform vec4 f4;
+
+uniform int i1;
+uniform ivec2 i2;
+uniform ivec3 i3;
+uniform ivec4 i4;
+
+uniform uint ui1;
+uniform uvec2 ui2;
+uniform uvec3 ui3;
+uniform uvec4 ui4;
+
+const vec3 BLACK = vec3(0.0, 0.0, 0.0);
+const vec3 WHITE = vec3(1.0, 1.0, 1.0);
+const vec2 SQUARE_SIZE = vec2(0.1, 0.1);
+
+// 長方形の外側ならプラス、内側ならマイナス
+float sdBox(vec2 p, vec2 size) {
+    vec2 d = abs(p) - size;
+    return min(max(d.x, d.y), 0.0) + length(max(d, 0.0));
+}
+
+// 水平バー
+float sdHBar(vec2 p, vec2 size, float rate) {
+    vec2 size1 = vec2(mix(0.0, size.x, rate), size.y);
+    vec2 p1 = vec2(p.x + mix(size.x, 0.0, rate), p.y);
+    return sdBox(p1, size1);
+}
+
+// 垂直バー
+float sdVBar(vec2 p, vec2 size, float rate) {
+    vec2 size1 = vec2(size.x, mix(0.0, size.y, rate));
+    vec2 p1 = vec2(p.x, p.y - mix(size.y, 0.0, rate));
+    return sdBox(p1, size1);
+}
+
+// 水平線
+float sdHLine(vec2 p, float thick) {
+    return abs(p.y) - thick;
+}
+
+// 垂直線
+float sdVLine(vec2 p, float thick) {
+    return abs(p.x) - thick;
+}
+
+//
+vec2 gridXY(vec2 p, vec2 xy) {
+    return p - vec2(-0.9) - xy * 0.2;
+}
+
+void main() {
+    vec2 p = (gl_FragCoord.xy * 2.0 - resolution) / min(resolution.x, resolution.y);
+    vec3 color = BLACK;
+
+    // グリッド (0, 0) time / totalTime
+    color = mix(vec3(1.0, 0.0, 0.0), color, step(0.0, sdHBar(gridXY(p, vec2(0.0, 0.0)), SQUARE_SIZE, time / totalTime)));
+    // グリッド (1, 0) frame / totalFrame
+    color = mix(vec3(1.0, 0.0, 0.0), color, step(0.0, sdVBar(gridXY(p, vec2(1.0, 0.0)), SQUARE_SIZE, float(frame) / float(totalFrame))));
+
+    // グリッド (0, 1) track0
+    color = mix(vec3(0.0, 1.0, 0.0), color, step(0.0, sdVBar(gridXY(p, vec2(0.0, 1.0)), SQUARE_SIZE, track.x / 10000.0)));
+    // グリッド (1, 1) track1
+    color = mix(vec3(0.0, 1.0, 0.0), color, step(0.0, sdVBar(gridXY(p, vec2(1.0, 1.0)), SQUARE_SIZE, track.y / 10000.0)));
+    // グリッド (2, 1) track2
+    color = mix(vec3(0.0, 1.0, 0.0), color, step(0.0, sdVBar(gridXY(p, vec2(2.0, 1.0)), SQUARE_SIZE, track.z / 10000.0)));
+    // グリッド (3, 1) track3
+    color = mix(vec3(0.0, 1.0, 0.0), color, step(0.0, sdVBar(gridXY(p, vec2(3.0, 1.0)), SQUARE_SIZE, track.w / 10000.0)));
+
+    // グリッド (0, 2) f1
+    color = mix(vec3(f1), color, step(0.0, sdBox(gridXY(p, vec2(0.0, 2.0)), SQUARE_SIZE)));
+    // グリッド (1, 2) f2
+    color = mix(vec3(f2, 0.0), color, step(0.0, sdBox(gridXY(p, vec2(1.0, 2.0)), SQUARE_SIZE)));
+    // グリッド (2, 2) f3
+    color = mix(f3, color, step(0.0, sdBox(gridXY(p, vec2(2.0, 2.0)), SQUARE_SIZE)));
+    // グリッド (3, 2) f4.xyz
+    color = mix(f4.xyz, color, step(0.0, sdBox(gridXY(p, vec2(3.0, 2.0)), SQUARE_SIZE)));
+    // グリッド (4, 2) f4.w
+    color = mix(vec3(f4.w), color, step(0.0, sdBox(gridXY(p, vec2(4.0, 2.0)), SQUARE_SIZE)));
+
+    // グリッド (0, 3) i1
+    color = mix(vec3(i1) / 255.0, color, step(0.0, sdBox(gridXY(p, vec2(0.0, 3.0)), SQUARE_SIZE)));
+    // グリッド (1, 3) i2
+    color = mix(vec3(i2, 0.0) / 255.0, color, step(0.0, sdBox(gridXY(p, vec2(1.0, 3.0)), SQUARE_SIZE)));
+    // グリッド (2, 3) i3
+    color = mix(i3 / 255.0, color, step(0.0, sdBox(gridXY(p, vec2(2.0, 3.0)), SQUARE_SIZE)));
+    // グリッド (3, 3) i4.xyz
+    color = mix(i4.xyz / 255.0, color, step(0.0, sdBox(gridXY(p, vec2(3.0, 3.0)), SQUARE_SIZE)));
+    // グリッド (4, 3) i4.w
+    color = mix(vec3(i4.w) / 255.0, color, step(0.0, sdBox(gridXY(p, vec2(4.0, 3.0)), SQUARE_SIZE)));
+
+    // グリッド (0, 4) ui1
+    color = mix(vec3(ui1) / 255.0, color, step(0.0, sdBox(gridXY(p, vec2(0.0, 4.0)), SQUARE_SIZE)));
+    // グリッド (1, 4) ui2
+    color = mix(vec3(ui2, 0.0) / 255.0, color, step(0.0, sdBox(gridXY(p, vec2(1.0, 4.0)), SQUARE_SIZE)));
+    // グリッド (2, 4) ui3
+    color = mix(ui3 / 255.0, color, step(0.0, sdBox(gridXY(p, vec2(2.0, 4.0)), SQUARE_SIZE)));
+    // グリッド (3, 4) ui4.xyz
+    color = mix(ui4.xyz / 255.0, color, step(0.0, sdBox(gridXY(p, vec2(3.0, 4.0)), SQUARE_SIZE)));
+    // グリッド (4, 4) ui4.w
+    color = mix(vec3(ui4.w) / 255.0, color, step(0.0, sdBox(gridXY(p, vec2(4.0, 4.0)), SQUARE_SIZE)));
+
+    // グリッド (10x10)
+    color = mix(vec3(0.5, 0.5, 0.5), color, step(0.0, sdHLine(fract(p * 5.0), 0.05)));
+    color = mix(vec3(0.5, 0.5, 0.5), color, step(0.0, sdVLine(fract(p * 5.0), 0.05)));
+
+    FragColor = vec4(color, 1.0);
+}

--- a/example/GLShaderKit_uniform.obj
+++ b/example/GLShaderKit_uniform.obj
@@ -48,6 +48,22 @@ if GLShaderKit.isInitialized() then
     GLShaderKit.setUInt("ui3", 128, 255, 128)
     GLShaderKit.setUInt("ui4", 255, 128, 128, 192)
 
+    GLShaderKit.setMatrix("m2", "2x2", false, {0.0, 0.3, 0.6, 1.0})
+    GLShaderKit.setMatrix("m2t", "2x2", true, {0.0, 0.3, 0.6, 1.0})
+    GLShaderKit.setMatrix("m3", "3x3", false, {1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0})
+    GLShaderKit.setMatrix("m4", "4x4", false, {
+        1.0, 0.0, 0.0, 0.0,
+        1.0, 0.0, 0.0, 0.0,
+        1.0, 0.0, 1.0, 1.0,
+        1.0, 0.0, 1.0, 0.0
+    })
+    GLShaderKit.setMatrix("m2x3", "2x3", false, {1.0, 0.0, 0.0, 0.0, 1.0, 0.0})
+    GLShaderKit.setMatrix("m3x2", "3x2", false, {0.0, 0.0, 1.0, 0.0, 1.0, 1.0})
+    GLShaderKit.setMatrix("m2x4", "2x4", false, {1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0})
+    GLShaderKit.setMatrix("m4x2", "4x2", false, {1.0, 0.0, 1.0, 1.0, 1.0, 0.0, 1.0, 0.0})
+    GLShaderKit.setMatrix("m3x4", "3x4", false, {1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 1.0})
+    GLShaderKit.setMatrix("m4x3", "4x3", false, {1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 1.0})
+
     GLShaderKit.draw("TRIANGLES", data, w, h)
 
     GLShaderKit.deactivate()

--- a/example/GLShaderKit_uniform.obj
+++ b/example/GLShaderKit_uniform.obj
@@ -1,0 +1,56 @@
+--[[
+    Uniform変数
+]]
+--track0:track0,0,10000,0
+--track1:track1,0,10000,0
+--track2:track2,0,10000,0
+--track3:track3,0,10000,0
+--check0:再読込,0
+
+local GLShaderKit = require "GLShaderKit"
+
+local width = 720
+local height = 720
+local shader_path = obj.getinfo("script_path") .. "GLShaderKit_uniform.frag"
+local force_reload = obj.check0
+
+local VERTEX_NUM = 1
+
+obj.setoption("drawtarget", "tempbuffer", width, height)
+obj.load("tempbuffer")
+local data, w, h = obj.getpixeldata()
+
+if GLShaderKit.isInitialized() then
+    GLShaderKit.activate()
+
+    GLShaderKit.setPlaneVertex(VERTEX_NUM)
+    GLShaderKit.setShader(shader_path, force_reload)
+
+    GLShaderKit.setFloat("resolution", width, height)
+    GLShaderKit.setFloat("time", obj.time)
+    GLShaderKit.setFloat("totalTime", obj.totaltime)
+    GLShaderKit.setInt("frame", obj.frame)
+    GLShaderKit.setInt("totalFrame", obj.totalframe)
+    GLShaderKit.setFloat("track", obj.track0, obj.track1, obj.track2, obj.track3)
+
+    GLShaderKit.setFloat("f1", 1.0)
+    GLShaderKit.setFloat("f2", 1.0, 0.0)
+    GLShaderKit.setFloat("f3", 0.5, 1.0, 0.5)
+    GLShaderKit.setFloat("f4", 1.0, 0.5, 0.5, 0.75)
+
+    GLShaderKit.setInt("i1", 255)
+    GLShaderKit.setInt("i2", 255, 0)
+    GLShaderKit.setInt("i3", 128, 255, 128)
+    GLShaderKit.setInt("i4", 255, 128, 128, 192)
+
+    GLShaderKit.setUInt("ui1", 255)
+    GLShaderKit.setUInt("ui2", 255, 0)
+    GLShaderKit.setUInt("ui3", 128, 255, 128)
+    GLShaderKit.setUInt("ui4", 255, 128, 128, 192)
+
+    GLShaderKit.draw("TRIANGLES", data, w, h)
+
+    GLShaderKit.deactivate()
+end
+
+obj.putpixeldata(data)

--- a/example/GLShaderKit_uniform.vert
+++ b/example/GLShaderKit_uniform.vert
@@ -1,0 +1,11 @@
+#version 460 core
+
+layout(location = 0) in vec3 iPos;
+layout(location = 1) in vec2 iTexCoord;
+
+out vec2 TexCoord;
+
+void main() {
+    gl_Position = vec4(iPos, 1.0);
+    TexCoord = iTexCoord;
+}

--- a/src/gl_context.cpp
+++ b/src/gl_context.cpp
@@ -247,87 +247,13 @@ void GLContext::Draw(GLenum mode, void* data, int width, int height, int instanc
     GLFramebuffer::Unbind();
 }
 
-void GLContext::SetFloat(const char* name, float v0) {
+GLint GLContext::GetUniformLocation(const char* name) const {
     auto current = shaderManager_.Current();
     if (current) {
-        glUniform1f(current->shader.GetUniformLocation(name), v0);
+        return current->shader.GetUniformLocation(name);
     }
-}
-
-void GLContext::SetVec2(const char* name, float v0, float v1) {
-    auto current = shaderManager_.Current();
-    if (current) {
-        glUniform2f(current->shader.GetUniformLocation(name), v0, v1);
-    }
-}
-
-void GLContext::SetVec3(const char* name, float v0, float v1, float v2) {
-    auto current = shaderManager_.Current();
-    if (current) {
-        glUniform3f(current->shader.GetUniformLocation(name), v0, v1, v2);
-    }
-}
-
-void GLContext::SetVec4(const char* name, float v0, float v1, float v2, float v3) {
-    auto current = shaderManager_.Current();
-    if (current) {
-        glUniform4f(current->shader.GetUniformLocation(name), v0, v1, v2, v3);
-    }
-}
-
-void GLContext::SetInt(const char* name, int v0) {
-    auto current = shaderManager_.Current();
-    if (current) {
-        glUniform1i(current->shader.GetUniformLocation(name), v0);
-    }
-}
-
-void GLContext::SetIVec2(const char* name, int v0, int v1) {
-    auto current = shaderManager_.Current();
-    if (current) {
-        glUniform2i(current->shader.GetUniformLocation(name), v0, v1);
-    }
-}
-
-void GLContext::SetIVec3(const char* name, int v0, int v1, int v2) {
-    auto current = shaderManager_.Current();
-    if (current) {
-        glUniform3i(current->shader.GetUniformLocation(name), v0, v1, v2);
-    }
-}
-
-void GLContext::SetIVec4(const char* name, int v0, int v1, int v2, int v3) {
-    auto current = shaderManager_.Current();
-    if (current) {
-        glUniform4i(current->shader.GetUniformLocation(name), v0, v1, v2, v3);
-    }
-}
-
-void GLContext::SetUInt(const char* name, uint32_t v0) {
-    auto current = shaderManager_.Current();
-    if (current) {
-        glUniform1ui(current->shader.GetUniformLocation(name), v0);
-    }
-}
-
-void GLContext::SetUVec2(const char* name, uint32_t v0, uint32_t v1) {
-    auto current = shaderManager_.Current();
-    if (current) {
-        glUniform2ui(current->shader.GetUniformLocation(name), v0, v1);
-    }
-}
-
-void GLContext::SetUVec3(const char* name, uint32_t v0, uint32_t v1, uint32_t v2) {
-    auto current = shaderManager_.Current();
-    if (current) {
-        glUniform3ui(current->shader.GetUniformLocation(name), v0, v1, v2);
-    }
-}
-
-void GLContext::SetUVec4(const char* name, uint32_t v0, uint32_t v1, uint32_t v2, uint32_t v3) {
-    auto current = shaderManager_.Current();
-    if (current) {
-        glUniform4ui(current->shader.GetUniformLocation(name), v0, v1, v2, v3);
+    else {
+        return -1;
     }
 }
 

--- a/src/gl_context.cpp
+++ b/src/gl_context.cpp
@@ -303,6 +303,34 @@ void GLContext::SetIVec4(const char* name, int v0, int v1, int v2, int v3) {
     }
 }
 
+void GLContext::SetUInt(const char* name, uint32_t v0) {
+    auto current = shaderManager_.Current();
+    if (current) {
+        glUniform1ui(current->shader.GetUniformLocation(name), v0);
+    }
+}
+
+void GLContext::SetUVec2(const char* name, uint32_t v0, uint32_t v1) {
+    auto current = shaderManager_.Current();
+    if (current) {
+        glUniform2ui(current->shader.GetUniformLocation(name), v0, v1);
+    }
+}
+
+void GLContext::SetUVec3(const char* name, uint32_t v0, uint32_t v1, uint32_t v2) {
+    auto current = shaderManager_.Current();
+    if (current) {
+        glUniform3ui(current->shader.GetUniformLocation(name), v0, v1, v2);
+    }
+}
+
+void GLContext::SetUVec4(const char* name, uint32_t v0, uint32_t v1, uint32_t v2, uint32_t v3) {
+    auto current = shaderManager_.Current();
+    if (current) {
+        glUniform4ui(current->shader.GetUniformLocation(name), v0, v1, v2, v3);
+    }
+}
+
 void GLContext::SetTexture2D(int unit, const void* data, int width, int height) {
     textures_.emplace(data, width, height);
     textures_.top().Bind(unit);

--- a/src/gl_context.hpp
+++ b/src/gl_context.hpp
@@ -67,6 +67,11 @@ public:
     void SetIVec3(const char* name, int v0, int v1, int v2);
     void SetIVec4(const char* name, int v0, int v1, int v2, int v3);
 
+    void SetUInt(const char* name, uint32_t v0);
+    void SetUVec2(const char* name, uint32_t v0, uint32_t v1);
+    void SetUVec3(const char* name, uint32_t v0, uint32_t v1, uint32_t v2);
+    void SetUVec4(const char* name, uint32_t v0, uint32_t v1, uint32_t v2, uint32_t v3);
+
     void SetTexture2D(int unit, const void* data, int width, int height);
 
     // GLの情報を取得

--- a/src/gl_context.hpp
+++ b/src/gl_context.hpp
@@ -57,20 +57,7 @@ public:
     void SetShader(const std::string& path, bool forceReload);
     void Draw(GLenum mode, void* data, int width, int height, int instanceCount);
 
-    void SetFloat(const char* name, float v0);
-    void SetVec2(const char* name, float v0, float v1);
-    void SetVec3(const char* name, float v0, float v1, float v2);
-    void SetVec4(const char* name, float v0, float v1, float v2, float v3);
-
-    void SetInt(const char* name, int v0);
-    void SetIVec2(const char* name, int v0, int v1);
-    void SetIVec3(const char* name, int v0, int v1, int v2);
-    void SetIVec4(const char* name, int v0, int v1, int v2, int v3);
-
-    void SetUInt(const char* name, uint32_t v0);
-    void SetUVec2(const char* name, uint32_t v0, uint32_t v1);
-    void SetUVec3(const char* name, uint32_t v0, uint32_t v1, uint32_t v2);
-    void SetUVec4(const char* name, uint32_t v0, uint32_t v1, uint32_t v2, uint32_t v3);
+    GLint GetUniformLocation(const char* name) const;
 
     void SetTexture2D(int unit, const void* data, int width, int height);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -181,6 +181,30 @@ int setInt(lua_State* L) {
     return 0;
 }
 
+int setUInt(lua_State* L) {
+    int top = lua_gettop(L);
+    if (top < 2) {
+        return luaL_error(L, "setUInt()には引数が2から5個の引数が必要です");
+    }
+    const char* name = lua_tostring(L, 1);
+    auto& context = glshaderkit::GLContext::Instance();
+    switch (top) {
+    case 2:
+        context.SetUInt(name, lua_tointeger(L, 2));
+        break;
+    case 3:
+        context.SetUVec2(name, lua_tointeger(L, 2), lua_tointeger(L, 3));
+        break;
+    case 4:
+        context.SetUVec3(name, lua_tointeger(L, 2), lua_tointeger(L, 3), lua_tointeger(L, 4));
+        break;
+    case 5:
+        context.SetUVec4(name, lua_tointeger(L, 2), lua_tointeger(L, 3), lua_tointeger(L, 4), lua_tointeger(L, 5));
+        break;
+    }
+    return 0;
+}
+
 int setTexture2D(lua_State* L) {
     if (lua_gettop(L) < 4) {
         return luaL_error(L, "setTexture2D()には引数が4個必要です");
@@ -214,6 +238,7 @@ static const luaL_Reg kLibFunctions[] = {
     {"draw", draw},
     {"setFloat", setFloat},
     {"setInt", setInt},
+    {"setUInt", setUInt},
     {"setTexture2D", setTexture2D},
     {nullptr, nullptr},
 };


### PR DESCRIPTION
ユニフォーム変数設定用の関数 `setUInt` , `setMatrix` の追加 (#1)

## setUInt
`setUInt` については `setFloat` , `setInt` と同様
以下のようなユニフォーム変数に対して
```glsl
uniform uint ui1;
uniform uvec2 ui2;
uniform uvec3 ui3;
uniform uvec4 ui4;
```
Luaスクリプトは以下の通り
```lua
GLShaderKit.setUInt("ui1", 255)
GLShaderKit.setUInt("ui2", 255, 0)
GLShaderKit.setUInt("ui3", 128, 255, 128)
GLShaderKit.setUInt("ui4", 255, 128, 128, 192)
```

## setMatrix
`setMatrix` については以下の形式
```
setMatrix(name, type, transpose, value)
```
| 引数名 | 型 | 内容 |
|---------|----|------|
| `name` | 文字列 | ユニフォーム変数名 |
| `type` | 文字列 | 行列の形 (`2x2`, `3x3`, `4x4`, `2x3`, `3x2`, `2x4`, `4x2`, `3x4`, `4x3`) |
| `transpose` | ブール | `true` なら転置する |
| `value` | 数値配列 | 行列の各要素の値。要素数は行列の要素数ちょうどであること |

以下のようなユニフォーム変数に対して
```glsl
uniform mat2 m2;
```
Luaスクリプトは以下の通り
```lua
GLShaderKit.setMatrix("m2", "2x2", false, {0.0, 0.3, 0.6, 1.0})
```