### PR TITLE
#12 デフォルト頂点シェーダーの追加

### DIFF
--- a/example/GLShaderKit_effect_02.frag
+++ b/example/GLShaderKit_effect_02.frag
@@ -1,0 +1,17 @@
+#version 460 core
+
+in vec2 TexCoord;
+
+layout(location = 0) out vec4 FragColor;
+
+uniform sampler2D texture0;
+
+uniform vec4 track;
+
+// RGB各チャネルにトラックバーで指定した倍率 (x0 - 2) をかける
+void main() {
+    vec4 color = texture(texture0, TexCoord);
+    vec3 rate = track.xyz / 10000.0 + 1.0;
+    color.rgb = color.rgb * rate;
+    FragColor = color;
+}

--- a/src/gl_shader.hpp
+++ b/src/gl_shader.hpp
@@ -34,7 +34,7 @@ private:
     static std::string LoadShaderSource(const std::filesystem::path& basePath);
     static GLuint CompileShader(const char* source, GLenum type);
 
-    void AttachShaderIfExists(const std::filesystem::path& path, GLenum type);
+    void AttachShaderIfExists(const std::filesystem::path& path, GLenum type, const char* defaultSource = nullptr);
 
     void Release();
 


### PR DESCRIPTION
頂点シェーダーファイルが見つからなかったときにデフォルトの頂点シェーダーを使用するようにした (#12)
使用するデフォルト頂点シェーダーは以下の通り
```glsl
#version 460 core

layout(location = 0) in vec3 iPos;
layout(location = 1) in vec2 iTexCoord;

out vec2 TexCoord;

void main() {
    gl_Position = vec4(iPos, 1.0);
    TexCoord = iTexCoord;
}
```
頂点配列オブジェクトは `setPlaneVertex` で指定することを想定している