### PR TITLE
#5 ユーザーデータの導入 (Texture, FrameBuffer, Vertex, Program)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,9 +33,11 @@ add_library(GLShaderKit SHARED
     src/lua_helper.cpp
     src/gl_context.cpp
     src/gl_shader.cpp
+    src/gl_shader_manager.cpp
     src/gl_framebuffer.cpp
     src/gl_vertex.cpp
     src/gl_texture.cpp
+    src/gl_uniform.cpp
     ${GLAD_SOURCE_DIR}/gl.c
     ${GLAD_SOURCE_DIR}/wgl.c
 )
@@ -67,8 +69,9 @@ add_executable(GLShaderKit_test
     tests/test_config.cpp
     tests/test_release.cpp
     src/release.cpp
+    tests/test_cache.cpp
 )
-target_include_directories(GLShaderKit_test PUBLIC src)
+target_include_directories(GLShaderKit_test PUBLIC src tests)
 target_link_libraries(GLShaderKit_test
     PRIVATE
         GTest::gmock_main
@@ -102,6 +105,9 @@ add_custom_target(debug_deploy ALL
         ${PROJECT_SOURCE_DIR}/example/GLShaderKit_drawPoints.obj
         ${PROJECT_SOURCE_DIR}/example/GLShaderKit_effect.anm
         ${PROJECT_SOURCE_DIR}/example/GLShaderKit_effectInstanced.anm
+        ${PROJECT_SOURCE_DIR}/example/GLShaderKit_multiShader.obj
+        ${PROJECT_SOURCE_DIR}/example/GLShaderKit_multiShader_1.frag
+        ${PROJECT_SOURCE_DIR}/example/GLShaderKit_multiShader_2.frag
         ${PROJECT_SOURCE_DIR}/example/GLShaderKit_multiTexture.obj
         ${PROJECT_SOURCE_DIR}/example/GLShaderKit_multiTexture.frag
         ${PROJECT_SOURCE_DIR}/example/GLShaderKit_multiTexture.vert

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,10 +5,15 @@ project(aviutl_GLShaderKit
     VERSION 0.4.0
 )
 
+enable_testing()
+
 # C++ の設定
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
+
+# GoogleTest
+find_package(GTest CONFIG REQUIRED)
 
 # Lua 5.1.4
 set(LUA_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/vendor/lua/include)
@@ -62,6 +67,33 @@ target_compile_definitions(GLShaderKit
         NOMINMAX
 )
 
+# テスト用実行ファイル
+add_executable(GLShaderKit_test
+    tests/test_config.cpp
+)
+target_include_directories(GLShaderKit_test PUBLIC src)
+target_link_libraries(GLShaderKit_test
+    PRIVATE
+        GTest::gtest_main
+)
+target_compile_options(GLShaderKit_test
+    PRIVATE
+        "$<$<CXX_COMPILER_ID:MSVC>:/source-charset:utf-8>"
+        "$<$<CXX_COMPILER_ID:MSVC>:/execution-charset:shift_jis>"
+)
+target_compile_definitions(GLShaderKit_test
+    PRIVATE
+        GL_SHADER_KIT_VERSION="${PROJECT_VERSION}"
+        NOMINMAX
+)
+
+# テストデータ
+add_custom_command(TARGET GLShaderKit_test PRE_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+        ${CMAKE_SOURCE_DIR}/tests/data
+        ${CMAKE_BINARY_DIR}/data
+)
+
 # 検証用の AviUtl に配置
 add_custom_target(debug_deploy ALL
     ${CMAKE_COMMAND} -E make_directory ${AVIUTL_DIR}/script/GLShaderKit
@@ -99,3 +131,8 @@ add_custom_target(package
     DEPENDS GLShaderKit
     COMMENT "package -> publish/${PROJECT_NAME}_v${PROJECT_VERSION}.zip"
 )
+
+# CTest
+include(CTest)
+include(GoogleTest)
+gtest_discover_tests(GLShaderKit_test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,24 +29,19 @@ set(AVIUTL_DIR ${PROJECT_SOURCE_DIR}/bin/aviutl)
 # GLShaderKit.dll
 add_library(GLShaderKit SHARED
     src/main.cpp
-    src/log.hpp
-    src/config.hpp
-    src/gl_context.hpp
+    src/release.cpp
+    src/lua_helper.cpp
     src/gl_context.cpp
-    src/gl_shader.hpp
     src/gl_shader.cpp
-    src/gl_shader_manager.hpp
-    src/gl_framebuffer.hpp
     src/gl_framebuffer.cpp
-    src/gl_vertex.hpp
     src/gl_vertex.cpp
-    src/gl_texture.hpp
     src/gl_texture.cpp
     ${GLAD_SOURCE_DIR}/gl.c
     ${GLAD_SOURCE_DIR}/wgl.c
 )
 target_include_directories(GLShaderKit
     PRIVATE
+        src
         ${LUA_INCLUDE_DIR}
         ${GLAD_INCLUDE_DIR}
 )
@@ -70,11 +65,13 @@ target_compile_definitions(GLShaderKit
 # テスト用実行ファイル
 add_executable(GLShaderKit_test
     tests/test_config.cpp
+    tests/test_release.cpp
+    src/release.cpp
 )
 target_include_directories(GLShaderKit_test PUBLIC src)
 target_link_libraries(GLShaderKit_test
     PRIVATE
-        GTest::gtest_main
+        GTest::gmock_main
 )
 target_compile_options(GLShaderKit_test
     PRIVATE
@@ -114,6 +111,8 @@ add_custom_target(debug_deploy ALL
         ${PROJECT_SOURCE_DIR}/example/GLShaderKit_uniform.obj
         ${PROJECT_SOURCE_DIR}/example/GLShaderKit_uniform.frag
         ${PROJECT_SOURCE_DIR}/example/GLShaderKit_uniform.vert
+        ${PROJECT_SOURCE_DIR}/example/GLShaderKit_gaussianBlur.anm
+        ${PROJECT_SOURCE_DIR}/example/GLShaderKit_gaussianBlur.frag
         ${AVIUTL_DIR}/script/GLShaderKit
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
     DEPENDS GLShaderKit

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -5,7 +5,11 @@
             "name": "default",
             "binaryDir": "${sourceDir}/build",
             "generator": "Visual Studio 17 2022",
-            "architecture": "Win32"
+            "architecture": "Win32",
+            "cacheVariables": {
+                "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+                "VCPKG_TARGET_TRIPLET": "x86-windows"
+            }
         }
     ],
     "buildPresets": [
@@ -18,6 +22,24 @@
             "name": "release",
             "configurePreset": "default",
             "configuration": "Release"
+        }
+    ],
+    "testPresets": [
+        {
+            "name": "debug",
+            "configurePreset": "default",
+            "configuration": "Debug",
+            "output": {
+                "outputOnFailure": true
+            }
+        },
+        {
+            "name": "release",
+            "configurePreset": "default",
+            "configuration": "Release",
+            "output": {
+                "outputOnFailure": true
+            }
         }
     ]
 }

--- a/example/GLShaderKit_gaussianBlur.anm
+++ b/example/GLShaderKit_gaussianBlur.anm
@@ -1,0 +1,57 @@
+--[[
+    ガウシアンブラー
+    1個のシェーダーを繰り返し適用する
+
+    参考: https://www.rastergrid.com/blog/2010/09/efficient-gaussian-blur-with-linear-sampling/
+]]
+--track0:amount,0,100,0,1
+
+local GLSK = require("GLShaderKit")
+
+-- スクリプトと同じ場所に置いてあるフラグメントシェーダーを使う
+local shader_path = obj.getinfo("script_path") .. "GLShaderKit_gaussianBlur.frag"
+-- シェーダー適用回数
+local amount = math.floor(obj.track0)
+
+if GLSK.isInitialized() and amount > 0 then
+    -- コンテキスト有効化
+    GLSK.activate()
+    -- オブジェクトの画像データ取得
+    local data, w, h = obj.getpixeldata()
+    -- 画像データからテクスチャ作成
+    local tex = GLSK.createTexture(data, w, h)
+    -- フレームバッファオブジェクト作成
+    local srcFbo = GLSK.createFrameBuffer(w, h)
+    local dstFbo = GLSK.createFrameBuffer(w, h)
+    -- 頂点作成
+    local vao = GLSK.createVertex("PLANE", 1)
+    -- シェーダープログラムの作成
+    GLSK.setShader(shader_path, false)
+
+    for i = 1, amount * 2 do
+        -- ユニフォーム変数設定
+        GLSK.setFloat("resolution", w, h)
+        if i % 2 == 0 then
+            GLSK.setFloat("direction", 1, 0)
+        else
+            GLSK.setFloat("direction", 0, 1)
+        end
+        -- テクスチャ設定
+        if i == 1 then
+            tex:bind(0)
+        else
+            srcFbo:bindTexture(0)
+        end
+        -- 描画
+        vao:draw("TRIANGLES", dstFbo)
+        -- フレームバッファオブジェクトを入れ替え
+        srcFbo, dstFbo = dstFbo, srcFbo
+    end
+
+    -- 描画結果取得
+    srcFbo:readPixels(data)
+    obj.putpixeldata(data)
+
+    -- コンテキスト無効化
+    GLSK.deactivate()
+end

--- a/example/GLShaderKit_gaussianBlur.frag
+++ b/example/GLShaderKit_gaussianBlur.frag
@@ -1,0 +1,25 @@
+#version 460 core
+
+in vec2 TexCoord;
+
+layout(location = 0) out vec4 FragColor;
+
+uniform sampler2D texture0;
+
+uniform vec2 resolution;
+uniform vec2 direction;
+
+uniform float offset[3] = float[](0.0, 1.3846153846, 3.2307692308);
+uniform float weight[3] = float[](0.2270270270, 0.3162162162, 0.0702702703);
+
+// ガウシアンブラー
+// 参考: https://www.rastergrid.com/blog/2010/09/efficient-gaussian-blur-with-linear-sampling/
+void main() {
+    vec4 color = texture(texture0, TexCoord) * weight[0];
+    for (int i = 1; i < 3; i++) {
+        vec2 uvOffset = vec2(offset[i]) * direction / resolution;
+        color += texture(texture0, TexCoord + uvOffset) * weight[i];
+        color += texture(texture0, TexCoord - uvOffset) * weight[i];
+    }
+    FragColor = color;
+}

--- a/example/GLShaderKit_multiShader.obj
+++ b/example/GLShaderKit_multiShader.obj
@@ -1,0 +1,67 @@
+--[[
+    シェーダーを2個使う
+]]
+--track0:size,1,100,50,0.01
+--track1:rotate,-3600,3600,30,0.01
+--track2:shift,0,100,50,1
+
+local GLSK = require "GLShaderKit"
+
+-- スクリプトと同じ場所に置いてあるフラグメントシェーダーを使う
+local shader_path_1 = obj.getinfo("script_path") .. "GLShaderKit_multiShader_1.frag"
+local shader_path_2 = obj.getinfo("script_path") .. "GLShaderKit_multiShader_2.frag"
+
+-- 図形のサイズ
+local size = obj.track0 / 200
+-- 図形の回転角度
+local rotate = math.rad(obj.track1 % 360.0)
+-- 色ずれ量
+local shift = obj.track2
+
+-- 描画サイズ
+local width, height = 1600, 900
+
+obj.setoption("drawtarget", "tempbuffer", width, height)
+obj.load("tempbuffer")
+local data, w, h = obj.getpixeldata()
+
+if GLSK.isInitialized() then
+    -- コンテキスト有効化
+    GLSK.activate()
+
+    -- 頂点作成
+    local vao = GLSK.createVertex("PLANE", 1)
+    -- フレームバッファオブジェクト作成
+    local fbo1 = GLSK.createFrameBuffer(w, h)
+    local fbo2 = GLSK.createFrameBuffer(w, h)
+    -- シェーダープログラムの作成
+    local program1 = GLSK.createProgram(shader_path_1, false)
+    local program2 = GLSK.createProgram(shader_path_2, false)
+
+    -- シェーダー1の実行
+    program1:use()
+    program1:setFloat("resolution", w, h)
+    program1:setFloat("size", size)
+    local s = math.sin(rotate)
+    local c = math.cos(rotate)
+    program1:setMatrix("affine", "3x3", false, {
+        c, -s, 0,
+        s,  c, 0,
+        0,  0, 1
+    })
+    vao:draw("TRIANGLES", fbo1)
+
+    -- シェーダー2の実行
+    program2:use()
+    program2:setFloat("resolution", w, h)
+    program2:setFloat("shift", shift)
+    fbo1:bindTexture(0)
+    vao:draw("TRIANGLES", fbo2)
+
+    -- 描画結果取得
+    fbo2:readPixels(data)
+    obj.putpixeldata(data)
+
+    GLSK.deactivate()
+end
+

--- a/example/GLShaderKit_multiShader_1.frag
+++ b/example/GLShaderKit_multiShader_1.frag
@@ -1,0 +1,25 @@
+#version 460 core
+
+in vec2 TexCoord;
+
+layout(location = 0) out vec4 FragColor;
+
+uniform vec2 resolution;
+uniform float size;
+uniform mat3 affine;
+
+// 長方形のSDF
+float sdBox(vec2 p, vec2 size) {
+    vec2 d = abs(p) - size;
+    return min(max(d.x, d.y), 0.0) + length(max(d, 0.0));
+}
+
+// 図形の描画
+void main() {
+    vec2 p = (gl_FragCoord.xy * 2.0 - resolution) / min(resolution.x, resolution.y);
+    p = (affine * vec3(p, 1.0)).xy;
+
+    float color = 1.0 - step(0.0, sdBox(p, vec2(size)));
+
+    FragColor = vec4(vec3(color), 1.0);
+}

--- a/example/GLShaderKit_multiShader_2.frag
+++ b/example/GLShaderKit_multiShader_2.frag
@@ -1,0 +1,38 @@
+#version 460 core
+
+layout(binding = 0) uniform sampler2D texture0;
+
+in vec2 TexCoord;
+
+layout(location = 0) out vec4 FragColor;
+
+uniform vec2 resolution;
+uniform float shift;
+
+const float PI = 3.141592653589793;
+
+// dgree から radian に変換する
+float deg2rad(float deg) {
+    return deg / 180.0 * PI;
+}
+
+// ベクトルvを回転させる
+vec2 rotate(vec2 v, float deg) {
+    float rad = deg2rad(deg);
+    float c = cos(rad);
+    float s = sin(rad);
+    mat2 m = mat2(c, -s, s, c);
+    return m * v;
+}
+
+// 色ずれさせる
+void main() {
+    vec2 unit = vec2(1.0, 0.0);
+    vec2 uv1 = TexCoord + rotate(unit, 70.0) * shift / resolution;
+    vec2 uv2 = TexCoord + rotate(unit, 190.0) * shift / resolution;
+    vec2 uv3 = TexCoord + rotate(unit, -50.0) * shift / resolution;
+    vec4 c1 = texture(texture0, uv1);
+    vec4 c2 = texture(texture0, uv2);
+    vec4 c3 = texture(texture0, uv3);
+    FragColor = vec4(c1.r, c2.g, c3.b, 1.0);
+}

--- a/src/cache.hpp
+++ b/src/cache.hpp
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <list>
+#include <unordered_map>
+#include <optional>
+#include <utility>
+#include <functional>
+
+namespace glshaderkit {
+
+// ムーブのみ(コピー不可)なValue用のLRUキャッシュ
+template<typename Key, typename Value>
+class MoveOnlyLruCache {
+public:
+    using Item = std::pair<Key, Value>;
+    using Iterator = typename std::list<Item>::iterator;
+
+    explicit MoveOnlyLruCache(size_t capacity) : capacity_(capacity) {}
+
+    void Put(const Key& key, Value&& value) {
+        auto it = cacheItemMap_.find(key);
+
+        if (it != cacheItemMap_.end()) {
+            // 既に存在する場合、リストを更新して先頭へ
+            cacheItemList_.erase(it->second);
+            cacheItemMap_.erase(it);
+        } else if (cacheItemList_.size() >= capacity_) {
+            // キャパ超えたら末尾を削除
+            const auto& last = cacheItemList_.back();
+            cacheItemMap_.erase(last.first);
+            cacheItemList_.pop_back();
+        }
+
+        cacheItemList_.emplace_front(key, std::move(value));
+        cacheItemMap_[key] = cacheItemList_.begin();
+    }
+
+    std::optional<std::reference_wrapper<Value>> Get(const Key& key) {
+        auto it = cacheItemMap_.find(key);
+        if (it == cacheItemMap_.end()) {
+            return std::nullopt;
+        }
+        cacheItemList_.splice(cacheItemList_.begin(), cacheItemList_, it->second);
+        return std::ref(it->second->second);
+    }
+
+    void Erase(const Key& key) {
+        auto it = cacheItemMap_.find(key);
+        if (it != cacheItemMap_.end()) {
+            cacheItemList_.erase(it->second);
+            cacheItemMap_.erase(it);
+        }
+    }
+
+    void Clear() {
+        cacheItemMap_.clear();
+        cacheItemList_.clear();
+    }
+
+    size_t Size() const {
+        return cacheItemList_.size();
+    }
+
+    void SetCapacity(size_t capacity) {
+        capacity_ = capacity;
+    }
+
+private:
+    size_t capacity_;
+    std::list<Item> cacheItemList_;
+    std::unordered_map<Key, Iterator> cacheItemMap_;
+};
+
+} // namespace glshaderkit

--- a/src/gl_context.hpp
+++ b/src/gl_context.hpp
@@ -14,6 +14,7 @@
 #include "gl_shader.hpp"
 #include "gl_shader_manager.hpp"
 #include "gl_texture.hpp"
+#include "release.hpp"
 #include "config.hpp"
 #include "log.hpp"
 
@@ -49,6 +50,7 @@ public:
 
     // レンダリングコンテキストを無効化する
     void Deactivate() {
+        releaseContainer_.ReleaseAll();
         wglMakeCurrent(NULL, NULL);
     }
 
@@ -71,6 +73,10 @@ public:
             return "";
         }
         return reinterpret_cast<const char*>(str);
+    }
+
+    ReleaseContainer& GetReleaseContainer() {
+        return releaseContainer_;
     }
 
 private:
@@ -104,6 +110,7 @@ private:
     std::unique_ptr<GLVertex> vertex_;
     GLShaderManager shaderManager_;
     std::stack<GLTexture> textures_;
+    ReleaseContainer releaseContainer_;
 };
 
 } // namespace glshaderkit

--- a/src/gl_context.hpp
+++ b/src/gl_context.hpp
@@ -41,18 +41,9 @@ public:
     }
 
     // レンダリングコンテキストを有効化する
-    bool Activate() {
-        if (!initialized_) {
-            return false;
-        }
-        return wglMakeCurrent(hdc_, hglrc_);
-    }
-
+    bool Activate();
     // レンダリングコンテキストを無効化する
-    void Deactivate() {
-        releaseContainer_.ReleaseAll();
-        wglMakeCurrent(NULL, NULL);
-    }
+    void Deactivate();
 
     void SetPlaneVertex(int n);
     void SetPointVertex(int n);
@@ -77,6 +68,10 @@ public:
 
     ReleaseContainer& GetReleaseContainer() {
         return releaseContainer_;
+    }
+
+    GLShaderManager& GetShaderManager() {
+        return shaderManager_;
     }
 
 private:

--- a/src/gl_framebuffer.hpp
+++ b/src/gl_framebuffer.hpp
@@ -1,10 +1,13 @@
 #pragma once
 
 #include <glad/gl.h>
+#include <lua.hpp>
+
+#include "release.hpp"
 
 namespace glshaderkit {
 
-class GLFramebuffer {
+class GLFramebuffer : public IRelease {
 public:
     GLFramebuffer(GLsizei width, GLsizei height)
         : fbo_(0), texture_(0), width_(width), height_(height) {
@@ -34,6 +37,10 @@ public:
         glBindFramebuffer(GL_FRAMEBUFFER, 0);
     }
 
+    void BindTexture(int unit) const {
+        glBindTextureUnit(unit, texture_);
+    }
+
     GLsizei Width() const {
         return width_;
     }
@@ -42,15 +49,46 @@ public:
         return height_;
     }
 
+    void Release() override;
+
 private:
     void Initialize();
-    void Release();
 
     GLuint fbo_;
     GLuint texture_;
     GLsizei width_;
     GLsizei height_;
-
 };
+
+namespace lua {
+
+// FrameBufferのメタテーブル名
+constexpr const char* kFrameBufferMetaName = "GLShaderKit.FrameBuffer";
+
+inline GLFramebuffer* GetLuaFrameBuffer(lua_State* L, int index) {
+    return *static_cast<GLFramebuffer**>(luaL_checkudata(L, index, kFrameBufferMetaName));
+}
+
+// FrameBufferメタテーブルの登録
+void RegisterFrameBuffer(lua_State* L);
+
+// FrameBuffer作成
+int CreateFrameBuffer(lua_State* L);
+
+// ガベージコレクションメタメソッド
+int FrameBufferMetaGC(lua_State* L);
+
+// バインド
+int FrameBufferBind(lua_State* L);
+// バインド解除
+int FrameBufferUnbind(lua_State* L);
+// カラーバッファをテクスチャとしてバインド
+int FrameBufferBindTexture(lua_State* L);
+// カラーバッファのデータを取得
+int FrameBufferReadPixels(lua_State* L);
+// リリース
+int FrameBufferRelease(lua_State* L);
+
+} // namespace lua
 
 } // namespace glshaderkit

--- a/src/gl_shader.hpp
+++ b/src/gl_shader.hpp
@@ -2,8 +2,12 @@
 
 #include <string>
 #include <filesystem>
+#include <functional>
 
 #include <glad/gl.h>
+#include <lua.hpp>
+
+#include "gl_uniform.hpp"
 
 namespace glshaderkit {
 
@@ -40,5 +44,28 @@ private:
 
     GLuint program_;
 };
+
+namespace lua {
+
+// Programのメタテーブル名
+constexpr const char* kProgramMetaName = "GLShaderKit.Program";
+
+inline GLShader* GetLuaProgram(lua_State* L, int index) {
+    return *static_cast<GLShader**>(luaL_checkudata(L, index, kProgramMetaName));
+}
+
+// Programメタテーブルの登録
+void RegisterProgram(lua_State* L);
+
+// Program作成
+int CreateProgram(lua_State* L);
+
+int ProgramUse(lua_State* L);
+int ProgramSetFloat(lua_State* L);
+int ProgramSetInt(lua_State* L);
+int ProgramSetUInt(lua_State* L);
+int ProgramSetMatrix(lua_State* L);
+
+} // namespace lua
 
 } // namespace glshaderkit

--- a/src/gl_shader_manager.cpp
+++ b/src/gl_shader_manager.cpp
@@ -1,0 +1,81 @@
+#include "gl_shader_manager.hpp"
+
+namespace glshaderkit {
+
+GLShaderManager::GLShaderManager(size_t capacity)
+    : shaderCache_(capacity)
+    , current_(std::nullopt)
+{}
+
+void GLShaderManager::SetShader(const std::string& shaderPath, bool forceReload) {
+    // shaderCache_ から探す
+    auto cached = shaderCache_.Get(shaderPath);
+    if (cached) {
+        if (forceReload) {
+            shaderCache_.Put(shaderPath, GLShader(shaderPath));
+            current_ = shaderCache_.Get(shaderPath);
+        } else {
+            current_ = cached;
+        }
+        return;
+    }
+
+    // activeShaders_ から探す
+    auto activeIt = activeShaders_.find(shaderPath);
+    if (activeIt != activeShaders_.end()) {
+        if (forceReload) {
+            activeIt->second = GLShader(shaderPath);
+        }
+        current_ = std::ref(activeIt->second);
+        return;
+    }
+
+    // どこにもキャッシュされていない場合
+    shaderCache_.Put(shaderPath, GLShader(shaderPath));
+    current_ = shaderCache_.Get(shaderPath);
+}
+
+std::reference_wrapper<GLShader> GLShaderManager::CreateProgram(
+    const std::string& shaderPath,
+    bool forceReload
+) {
+    // activeShaders_ から探す
+    auto activeIt = activeShaders_.find(shaderPath);
+    if (activeIt != activeShaders_.end()) {
+        if (forceReload) {
+            activeIt->second = GLShader(shaderPath);
+        }
+        return std::ref(activeIt->second);
+    }
+
+    // shaderCache_ から探す
+    auto cached = shaderCache_.Get(shaderPath);
+    if (cached) {
+        GLShader shader = forceReload ? GLShader(shaderPath) : std::move(cached->get());
+        auto [it, success] = activeShaders_.emplace(shaderPath, std::move(shader));
+        shaderCache_.Erase(shaderPath);
+        return std::ref(it->second);
+    }
+
+    auto [it, success] = activeShaders_.emplace(shaderPath, GLShader(shaderPath));
+    return std::ref(it->second);
+}
+
+void GLShaderManager::CacheActiveShaders() {
+    for (auto& [path, shader] : activeShaders_) {
+        shaderCache_.Put(path, std::move(shader));
+    }
+    activeShaders_.clear();
+}
+
+void GLShaderManager::SetCapacity(size_t capacity) {
+    shaderCache_.SetCapacity(capacity);
+}
+
+void GLShaderManager::Release() {
+    current_ = std::nullopt;
+    activeShaders_.clear();
+    shaderCache_.Clear();
+}
+
+} // namespace glshaderkit

--- a/src/gl_texture.hpp
+++ b/src/gl_texture.hpp
@@ -1,10 +1,13 @@
 #pragma once
 
 #include <glad/gl.h>
+#include <lua.hpp>
+
+#include "release.hpp"
 
 namespace glshaderkit {
 
-class GLTexture {
+class GLTexture : public IRelease {
 public:
     GLTexture(const void* data, int width, int height);
     ~GLTexture() {
@@ -27,13 +30,41 @@ public:
         glBindTexture(GL_TEXTURE_2D, 0);
     }
 
+    void Release() override;
+
 private:
     void Initialize(const void* data);
-    void Release();
 
     GLuint texture_;
     int width_;
     int height_;
 };
+
+namespace lua {
+
+// Textureのメタテーブル名
+constexpr const char* kTextureMetaName = "GLShaderKit.Texture";
+
+inline GLTexture* GetLuaTexture(lua_State* L, int index) {
+    return *static_cast<GLTexture**>(luaL_checkudata(L, index, kTextureMetaName));
+}
+
+// Textureメタテーブルの登録
+void RegisterTexture(lua_State* L);
+
+// Texture作成
+int CreateTexture(lua_State* L);
+
+// ガベージコレクションメタメソッド
+int TextureMetaGC(lua_State* L);
+
+// バインド
+int TextureBind(lua_State* L);
+// バインド解除
+int TextureUnbind(lua_State* L);
+// リリース
+int TextureRelease(lua_State* L);
+
+} // namespace lua
 
 } // namespace glshaderkit

--- a/src/gl_uniform.cpp
+++ b/src/gl_uniform.cpp
@@ -1,0 +1,39 @@
+#include "gl_uniform.hpp"
+
+#include <string>
+
+#include "lua_helper.hpp"
+
+namespace glshaderkit {
+
+namespace lua {
+
+int SetUniformMatrix(lua_State* L, GLint location, int offset) {
+    int top = lua_gettop(L);
+    std::string matrixType = luaL_checkstring(L, offset + 1);
+    bool transpose = lua_toboolean(L, offset + 2);
+
+    if (!lua_istable(L, offset + 3)) {
+        return luaL_error(L, "引数に配列が指定されていません");
+    }
+
+    auto matrix = LuaTableToVector(L, offset + 3);
+    auto it = kGLMatrixSetterMap.find(matrixType);
+    if (it == kGLMatrixSetterMap.end()) {
+        return luaL_error(L, "'%s' は無効な行列の型です", matrixType.c_str());
+    }
+
+    const auto& setter = it->second;
+    if (matrix.size() != setter.size) {
+        return luaL_error(L,
+            "行列の要素数が無効です。 (期待値: %d, 実際の値: %d)",
+            setter.size, matrix.size());
+    }
+
+    setter.setter(location, 1, transpose, matrix.data());
+    return 0;
+}
+
+} // namespace lua
+
+} // namespace glshaderkit

--- a/src/gl_uniform.hpp
+++ b/src/gl_uniform.hpp
@@ -1,0 +1,114 @@
+#pragma once
+
+#include <string_view>
+#include <unordered_map>
+#include <functional>
+
+#include <glad/gl.h>
+#include <lua.hpp>
+
+namespace glshaderkit {
+
+template<typename T>
+using GLUniformFunc1 = void (GLAD_API_PTR *)(GLint, T);
+template<typename T>
+using GLUniformFunc2 = void (GLAD_API_PTR *)(GLint, T, T);
+template<typename T>
+using GLUniformFunc3 = void (GLAD_API_PTR *)(GLint, T, T, T);
+template<typename T>
+using GLUniformFunc4 = void (GLAD_API_PTR *)(GLint, T, T, T, T);
+
+using GLUniformMatrixFunc = void (GLAD_API_PTR *)(GLint, GLsizei, GLboolean, const GLfloat*);
+
+template<typename T>
+struct GLUniformSetter {
+    std::reference_wrapper<GLUniformFunc1<T>> setter1;
+    std::reference_wrapper<GLUniformFunc2<T>> setter2;
+    std::reference_wrapper<GLUniformFunc3<T>> setter3;
+    std::reference_wrapper<GLUniformFunc4<T>> setter4;
+};
+
+struct GLUniformMatrixSetter {
+    size_t size;
+    std::reference_wrapper<GLUniformMatrixFunc> setter;
+};
+
+inline const GLUniformSetter<GLfloat> kGLUniformFloatSetter {
+    glUniform1f,
+    glUniform2f,
+    glUniform3f,
+    glUniform4f,
+};
+inline const GLUniformSetter<GLint> kGLUniformIntSetter {
+    glUniform1i,
+    glUniform2i,
+    glUniform3i,
+    glUniform4i,
+};
+inline const GLUniformSetter<GLuint> kGLUniformUIntSetter {
+    glUniform1ui,
+    glUniform2ui,
+    glUniform3ui,
+    glUniform4ui,
+};
+
+inline const std::unordered_map<std::string_view, GLUniformMatrixSetter> kGLMatrixSetterMap = {
+    {"2x2", {4, glUniformMatrix2fv}},
+    {"3x3", {9, glUniformMatrix3fv}},
+    {"4x4", {16, glUniformMatrix4fv}},
+    {"2x3", {6, glUniformMatrix2x3fv}},
+    {"3x2", {6, glUniformMatrix3x2fv}},
+    {"2x4", {8, glUniformMatrix2x4fv}},
+    {"4x2", {8, glUniformMatrix4x2fv}},
+    {"3x4", {12, glUniformMatrix3x4fv}},
+    {"4x3", {12, glUniformMatrix4x3fv}},
+};
+
+namespace lua {
+
+template<typename T>
+int SetUniform(
+    lua_State* L,
+    GLint location,
+    int offset,
+    std::function<T(lua_State*, int)> getter,
+    const GLUniformSetter<T>& setter
+) {
+    int num = lua_gettop(L) - offset;
+    switch (num) {
+    case 1: {
+        T v0 = getter(L, offset + 1);
+        setter.setter1(location, v0);
+        break;
+    }
+    case 2: {
+        T v0 = getter(L, offset + 1);
+        T v1 = getter(L, offset + 2);
+        setter.setter2(location, v0, v1);
+        break;
+    }
+    case 3: {
+        T v0 = getter(L, offset + 1);
+        T v1 = getter(L, offset + 2);
+        T v2 = getter(L, offset + 3);
+        setter.setter3(location, v0, v1, v2);
+        break;
+    }
+    case 4: {
+        T v0 = getter(L, offset + 1);
+        T v1 = getter(L, offset + 2);
+        T v2 = getter(L, offset + 3);
+        T v3 = getter(L, offset + 4);
+        setter.setter4(location, v0, v1, v2, v3);
+        break;
+    }
+    }
+    return 0;
+}
+
+int SetUniformMatrix(lua_State* L, GLint location, int offset);
+
+} // namespace lua
+
+
+} // namespace glshaderkit

--- a/src/gl_vertex.hpp
+++ b/src/gl_vertex.hpp
@@ -1,10 +1,13 @@
 #pragma once
 
 #include <glad/gl.h>
+#include <lua.hpp>
+
+#include "release.hpp"
 
 namespace glshaderkit {
 
-class GLVertex {
+class GLVertex : public IRelease {
 public:
     enum class Primitive{
         Plane,
@@ -12,6 +15,7 @@ public:
     };
 
     GLVertex(int n);
+    GLVertex(Primitive primitive, int n);
     ~GLVertex() {
         Release();
     }
@@ -47,9 +51,10 @@ public:
         return indexCount_;
     }
 
+    void Release() override;
+
 private:
     void Initialize(int n);
-    void Release();
 
     GLuint vao_;
     GLuint vbo_;
@@ -58,5 +63,34 @@ private:
     int size_;
     int indexCount_;
 };
+
+namespace lua {
+
+// Vertexのメタテーブル名
+constexpr const char* kVertexMetaName = "GLShaderKit.Vertex";
+
+inline GLVertex* GetLuaVertex(lua_State* L, int index) {
+    return *static_cast<GLVertex**>(luaL_checkudata(L, index, kVertexMetaName));
+}
+
+// Vertexメタテーブルの登録
+void RegisterVertex(lua_State* L);
+
+// Vertex作成
+int CreateVertex(lua_State* L);
+
+// ガベージコレクションメタメソッド
+int VertexMetaGC(lua_State* L);
+
+// バインド
+int VertexBind(lua_State* L);
+// バインド解除
+int VertexUnbind(lua_State* L);
+// VAOをフレームバッファに描画
+int VertexDraw(lua_State* L);
+// リリース
+int VertexRelease(lua_State* L);
+
+} // namespace lua
 
 } // namespace glshaderkit

--- a/src/lua_helper.cpp
+++ b/src/lua_helper.cpp
@@ -1,0 +1,56 @@
+#include "lua_helper.hpp"
+
+namespace glshaderkit::lua {
+
+void RegisterMetaTable(
+    lua_State* L,
+    const char* name,
+    const luaL_Reg* metaMethod,
+    const luaL_Reg* method
+) {
+    luaL_newmetatable(L, name);
+
+    luaL_register(L, nullptr, metaMethod);
+
+    lua_newtable(L);
+    luaL_register(L, nullptr, method);
+    lua_setfield(L, -2, "__index");
+
+    lua_pop(L, 1);
+}
+
+GLenum CheckDrawMode(lua_State* L, int narg) {
+    const char* texts[] = {
+        "POINTS",
+        "LINE_STRIP",
+        "LINE_LOOP",
+        "LINES",
+        "LINE_STRIP_ADJACENCY",
+        "LINES_ADJACENCY",
+        "TRIANGLE_STRIP",
+        "TRIANGLE_FAN",
+        "TRIANGLES",
+        "TRIANGLE_STRIP_ADJACENCY",
+        "TRIANGLES_ADJACENCY",
+        "PATCHES",
+        nullptr,
+    };
+    const GLenum modes[] = {
+        GL_POINTS,
+        GL_LINE_STRIP,
+        GL_LINE_LOOP,
+        GL_LINES,
+        GL_LINE_STRIP_ADJACENCY,
+        GL_LINES_ADJACENCY,
+        GL_TRIANGLE_STRIP,
+        GL_TRIANGLE_FAN,
+        GL_TRIANGLES,
+        GL_TRIANGLE_STRIP_ADJACENCY,
+        GL_TRIANGLES_ADJACENCY,
+        GL_PATCHES,
+    };
+    int index = luaL_checkoption(L, narg, "TRIANGLES", texts);
+    return modes[index];
+}
+
+} // namespace glshaderkit::lua

--- a/src/lua_helper.cpp
+++ b/src/lua_helper.cpp
@@ -53,4 +53,28 @@ GLenum CheckDrawMode(lua_State* L, int narg) {
     return modes[index];
 }
 
+GLfloat LuaToFloat(lua_State* L, int index) {
+    return static_cast<GLfloat>(lua_tonumber(L, index));
+}
+
+GLint LuaToInt(lua_State* L, int index) {
+    return static_cast<GLint>(lua_tointeger(L, index));
+}
+
+GLuint LuaToUInt (lua_State* L, int index) {
+    return static_cast<GLuint>(lua_tointeger(L, index));
+}
+
+std::vector<float> LuaTableToVector(lua_State* L, int index) {
+    std::vector<float> result;
+    lua_pushnil(L);
+    while (lua_next(L, index) != 0) {
+        if (lua_isnumber(L, -1)) {
+            result.push_back(static_cast<float>(lua_tonumber(L, -1)));
+        }
+        lua_pop(L, 1);
+    }
+    return result;
+}
+
 } // namespace glshaderkit::lua

--- a/src/lua_helper.hpp
+++ b/src/lua_helper.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <vector>
+
 #include <glad/gl.h>
 #include <lua.hpp>
 
@@ -14,5 +16,11 @@ void RegisterMetaTable(
 );
 
 GLenum CheckDrawMode(lua_State* L, int narg);
+
+GLfloat LuaToFloat(lua_State* L, int index);
+GLint LuaToInt(lua_State* L, int index);
+GLuint LuaToUInt (lua_State* L, int index);
+
+std::vector<float> LuaTableToVector(lua_State* L, int index);
 
 } // namespace glshaderkit::lua

--- a/src/lua_helper.hpp
+++ b/src/lua_helper.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <glad/gl.h>
+#include <lua.hpp>
+
+namespace glshaderkit::lua {
+
+// Luaに新しいメタテーブルを登録する
+void RegisterMetaTable(
+    lua_State* L,
+    const char* name,
+    const luaL_Reg* metaMethod,
+    const luaL_Reg* method
+);
+
+GLenum CheckDrawMode(lua_State* L, int narg);
+
+} // namespace glshaderkit::lua

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,6 +12,8 @@
 #include "gl_texture.hpp"
 #include "gl_framebuffer.hpp"
 #include "gl_vertex.hpp"
+#include "gl_shader.hpp"
+#include "gl_uniform.hpp"
 #include "lua_helper.hpp"
 #include "config.hpp"
 #include "log.hpp"
@@ -21,18 +23,6 @@
 #ifndef GL_SHADER_KIT_VERSION
 #   define GL_SHADER_KIT_VERSION "0.0.0"
 #endif
-
-std::vector<float> LuaTableToVector(lua_State* L, int index) {
-    std::vector<float> result;
-    lua_pushnil(L);
-    while (lua_next(L, index) != 0) {
-        if (lua_isnumber(L, -1)) {
-            result.push_back(static_cast<float>(lua_tonumber(L, -1)));
-        }
-        lua_pop(L, 1);
-    }
-    return result;
-}
 
 int version(lua_State* L) {
     lua_pushstring(L, GL_SHADER_KIT_VERSION);
@@ -122,131 +112,30 @@ int draw(lua_State* L) {
 }
 
 int setFloat(lua_State* L) {
-    int top = lua_gettop(L);
-    if (top < 2) {
-        return luaL_error(L, "setFloat()には引数が2から5個の引数が必要です");
-    }
-    const char* name = lua_tostring(L, 1);
-    auto& context = glshaderkit::GLContext::Instance();
-    auto location = context.GetUniformLocation(name);
-    switch (top) {
-    case 2:
-        glUniform1f(location, lua_tonumber(L, 2));
-        break;
-    case 3:
-        glUniform2f(location, lua_tonumber(L, 2), lua_tonumber(L, 3));
-        break;
-    case 4:
-        glUniform3f(location, lua_tonumber(L, 2), lua_tonumber(L, 3), lua_tonumber(L, 4));
-        break;
-    case 5:
-        glUniform4f(location, lua_tonumber(L, 2), lua_tonumber(L, 3), lua_tonumber(L, 4), lua_tonumber(L, 5));
-        break;
-    }
-    return 0;
+    const char* name = luaL_checkstring(L, 1);
+    auto location = glshaderkit::GLContext::Instance().GetUniformLocation(name);
+    return glshaderkit::lua::SetUniform<GLfloat>(L, location, 1,
+        glshaderkit::lua::LuaToFloat, glshaderkit::kGLUniformFloatSetter);
 }
 
 int setInt(lua_State* L) {
-    int top = lua_gettop(L);
-    if (top < 2) {
-        return luaL_error(L, "setInt()には引数が2から5個の引数が必要です");
-    }
-    const char* name = lua_tostring(L, 1);
-    auto& context = glshaderkit::GLContext::Instance();
-    auto location = context.GetUniformLocation(name);
-    switch (top) {
-    case 2:
-        glUniform1i(location, lua_tointeger(L, 2));
-        break;
-    case 3:
-        glUniform2i(location, lua_tointeger(L, 2), lua_tointeger(L, 3));
-        break;
-    case 4:
-        glUniform3i(location, lua_tointeger(L, 2), lua_tointeger(L, 3), lua_tointeger(L, 4));
-        break;
-    case 5:
-        glUniform4i(location, lua_tointeger(L, 2), lua_tointeger(L, 3), lua_tointeger(L, 4), lua_tointeger(L, 5));
-        break;
-    }
-    return 0;
+    const char* name = luaL_checkstring(L, 1);
+    auto location = glshaderkit::GLContext::Instance().GetUniformLocation(name);
+    return glshaderkit::lua::SetUniform<GLint>(L, location, 1,
+        glshaderkit::lua::LuaToInt, glshaderkit::kGLUniformIntSetter);
 }
 
 int setUInt(lua_State* L) {
-    int top = lua_gettop(L);
-    if (top < 2) {
-        return luaL_error(L, "setUInt()には引数が2から5個の引数が必要です");
-    }
-    const char* name = lua_tostring(L, 1);
-    auto& context = glshaderkit::GLContext::Instance();
-    auto location = context.GetUniformLocation(name);
-    switch (top) {
-    case 2:
-        glUniform1ui(location, lua_tointeger(L, 2));
-        break;
-    case 3:
-        glUniform2ui(location, lua_tointeger(L, 2), lua_tointeger(L, 3));
-        break;
-    case 4:
-        glUniform3ui(location, lua_tointeger(L, 2), lua_tointeger(L, 3), lua_tointeger(L, 4));
-        break;
-    case 5:
-        glUniform4ui(location, lua_tointeger(L, 2), lua_tointeger(L, 3), lua_tointeger(L, 4), lua_tointeger(L, 5));
-        break;
-    }
-    return 0;
+    const char* name = luaL_checkstring(L, 1);
+    auto location = glshaderkit::GLContext::Instance().GetUniformLocation(name);
+    return glshaderkit::lua::SetUniform<GLuint>(L, location, 1,
+        glshaderkit::lua::LuaToUInt, glshaderkit::kGLUniformUIntSetter);
 }
 
 int setMatrix(lua_State* L) {
-    int top = lua_gettop(L);
-
-    const char* name = lua_tostring(L, 1);
-    const char* matrixType = lua_tostring(L, 2);
-    const bool transpose = lua_toboolean(L, 3);
-    if (!lua_istable(L, 4)) {
-        return luaL_error(L, "第4引数には配列を指定してください");
-    }
-    auto matrix = LuaTableToVector(L, 4);
-
-    auto& context = glshaderkit::GLContext::Instance();
-    auto location = context.GetUniformLocation(name);
-
-    if (std::strcmp(matrixType, "2x2") == 0) {
-        if (matrix.size() != 4) return luaL_error(L, "配列の要素数が4ではありません");
-        glUniformMatrix2fv(location, 1, transpose, matrix.data());
-    }
-    else if (std::strcmp(matrixType, "3x3") == 0) {
-        if (matrix.size() != 9) return luaL_error(L, "配列の要素数が9ではありません");
-        glUniformMatrix3fv(location, 1, transpose, matrix.data());
-    }
-    else if (std::strcmp(matrixType, "4x4") == 0) {
-        if (matrix.size() != 16) return luaL_error(L, "配列の要素数が16ではありません");
-        glUniformMatrix4fv(location, 1, transpose, matrix.data());
-    }
-    else if (std::strcmp(matrixType, "2x3") == 0) {
-        if (matrix.size() != 6) return luaL_error(L, "配列の要素数が6ではありません");
-        glUniformMatrix2x3fv(location, 1, transpose, matrix.data());
-    }
-    else if (std::strcmp(matrixType, "3x2") == 0) {
-        if (matrix.size() != 6) return luaL_error(L, "配列の要素数が6ではありません");
-        glUniformMatrix3x2fv(location, 1, transpose, matrix.data());
-    }
-    else if (std::strcmp(matrixType, "2x4") == 0) {
-        if (matrix.size() != 8) return luaL_error(L, "配列の要素数が8ではありません");
-        glUniformMatrix2x4fv(location, 1, transpose, matrix.data());
-    }
-    else if (std::strcmp(matrixType, "4x2") == 0) {
-        if (matrix.size() != 8) return luaL_error(L, "配列の要素数が8ではありません");
-        glUniformMatrix4x2fv(location, 1, transpose, matrix.data());
-    }
-    else if (std::strcmp(matrixType, "3x4") == 0) {
-        if (matrix.size() != 12) return luaL_error(L, "配列の要素数が12ではありません");
-        glUniformMatrix3x4fv(location, 1, transpose, matrix.data());
-    }
-    else if (std::strcmp(matrixType, "4x3") == 0) {
-        if (matrix.size() != 12) return luaL_error(L, "配列の要素数が12ではありません");
-        glUniformMatrix4x3fv(location, 1, transpose, matrix.data());
-    }
-    return 0;
+    const char* name = luaL_checkstring(L, 1);
+    auto location = glshaderkit::GLContext::Instance().GetUniformLocation(name);
+    return glshaderkit::lua::SetUniformMatrix(L, location, 1);
 }
 
 int setTexture2D(lua_State* L) {
@@ -288,6 +177,7 @@ static const luaL_Reg kLibFunctions[] = {
     {"createTexture", glshaderkit::lua::CreateTexture},
     {"createFrameBuffer", glshaderkit::lua::CreateFrameBuffer},
     {"createVertex", glshaderkit::lua::CreateVertex},
+    {"createProgram", glshaderkit::lua::CreateProgram},
     {nullptr, nullptr},
 };
 
@@ -323,6 +213,7 @@ GL_SHADER_KIT_API int luaopen_GLShaderKit(lua_State* L) {
     glshaderkit::lua::RegisterTexture(L);
     glshaderkit::lua::RegisterFrameBuffer(L);
     glshaderkit::lua::RegisterVertex(L);
+    glshaderkit::lua::RegisterProgram(L);
 
     // Luaステートが閉じるときにGLコンテキストを解放させる
     void* ud = lua_newuserdata(L, 1);

--- a/src/release.cpp
+++ b/src/release.cpp
@@ -1,0 +1,31 @@
+#include "release.hpp"
+
+#include <algorithm>
+
+namespace glshaderkit {
+
+size_t ReleaseContainer::Size() const {
+    return targets_.size();
+}
+
+bool ReleaseContainer::Contains(IRelease* x) const {
+    return std::ranges::find(targets_, x) != targets_.end();
+}
+
+void ReleaseContainer::Add(IRelease* x) {
+    targets_.push_back(x);
+}
+
+void ReleaseContainer::Remove(IRelease* x) {
+    std::erase(targets_, x);
+}
+
+void ReleaseContainer::ReleaseAll() {
+    for (auto target : targets_) {
+        target->Release();
+    }
+    targets_.clear();
+}
+
+} // namespace glshaderkit
+

--- a/src/release.hpp
+++ b/src/release.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <vector>
+
+namespace glshaderkit {
+
+// リソースの解放処理をもつクラス用のインターフェース
+class IRelease {
+public:
+    virtual ~IRelease() = default;
+    virtual void Release() = 0;
+};
+
+// リリース対象をまとめるコンテナ
+class ReleaseContainer {
+public:
+    // 登録済みリリース対象の個数を取得する
+    size_t Size() const;
+
+    // 登録済みか確認する
+    bool Contains(IRelease* x) const;
+
+    // リリース対象として登録する
+    void Add(IRelease* x);
+
+    // リリース対象から登録解除する
+    void Remove(IRelease* x);
+
+    // 登録済みのリリース対象をすべてリリースする
+    void ReleaseAll();
+private:
+    // リリース対象
+    std::vector<IRelease*> targets_;
+};
+
+} // namespace glshaderkit

--- a/tests/data/config_load.ini
+++ b/tests/data/config_load.ini
@@ -1,0 +1,3 @@
+[config]
+; シェーダーのキャッシュ数
+shaderCacheCapacity = 16

--- a/tests/data/config_load_negative.ini
+++ b/tests/data/config_load_negative.ini
@@ -1,0 +1,3 @@
+[config]
+; シェーダーのキャッシュ数
+shaderCacheCapacity = -1

--- a/tests/move_only.hpp
+++ b/tests/move_only.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+class MoveOnly {
+public:
+    int x_;
+
+    explicit MoveOnly(int x) : x_(x) {}
+
+    // コピー禁止
+    MoveOnly(const MoveOnly&) = delete;
+    MoveOnly& operator=(const MoveOnly&) = delete;
+
+    // ムーブ
+    MoveOnly(MoveOnly&& other) : x_(other.x_) {
+        other.x_ = 0;
+    }
+
+    // ムーブ代入
+    MoveOnly& operator=(MoveOnly&& other) {
+        if (this != &other) {
+            x_ = other.x_;
+            other.x_ = 0;
+        }
+        return *this;
+    }
+};

--- a/tests/test_cache.cpp
+++ b/tests/test_cache.cpp
@@ -1,0 +1,118 @@
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "cache.hpp"
+#include "move_only.hpp"
+
+// キャッシュを捨てない範囲でPut, Getが機能するか
+TEST(MoveOnlyLruCacheTest, PutAndGet) {
+    glshaderkit::MoveOnlyLruCache<std::string, MoveOnly> cache(2);
+
+    cache.Put("one", MoveOnly(1));
+    cache.Put("two", MoveOnly(2));
+
+    auto one = cache.Get("one");
+    ASSERT_TRUE(one.has_value());
+    EXPECT_EQ(one->get().x_, 1);
+
+    auto two = cache.Get("two");
+    ASSERT_TRUE(two.has_value());
+    EXPECT_EQ(two->get().x_, 2);
+}
+
+// キャパシティ以上にPutすると捨てられるか
+TEST(MoveOnlyLruCacheTest, EvictionWorks) {
+    glshaderkit::MoveOnlyLruCache<std::string, MoveOnly> cache(2);
+
+    cache.Put("one", MoveOnly(1));
+    cache.Put("two", MoveOnly(2));
+    cache.Put("three", MoveOnly(3));    // "one" が捨てられるはず
+
+    auto one = cache.Get("one");
+    ASSERT_FALSE(one.has_value());
+
+    auto two = cache.Get("two");
+    ASSERT_TRUE(two.has_value());
+    EXPECT_EQ(two->get().x_, 2);
+
+    auto three = cache.Get("three");
+    ASSERT_TRUE(three.has_value());
+    EXPECT_EQ(three->get().x_, 3);
+}
+
+// Getしたものがキャッシュの先頭に移動するか
+TEST(MoveOnlyLruCacheTest, AccessUpdatesPriority) {
+    glshaderkit::MoveOnlyLruCache<std::string, MoveOnly> cache(2);
+
+    cache.Put("one", MoveOnly(1));
+    cache.Put("two", MoveOnly(2));
+
+    // "one" が先頭に移動する
+    cache.Get("one");
+
+    // "two" が捨てられるはず
+    cache.Put("three", MoveOnly(3));
+
+    auto one = cache.Get("one");
+    ASSERT_TRUE(one.has_value());
+    EXPECT_EQ(one->get().x_, 1);
+
+    auto two = cache.Get("two");
+    ASSERT_FALSE(two.has_value());
+
+    auto three = cache.Get("three");
+    ASSERT_TRUE(three.has_value());
+    EXPECT_EQ(three->get().x_, 3);
+}
+
+// 同じキーの値を上書きする
+TEST(MoveOnlyLruCacheTest, Overwrite) {
+    glshaderkit::MoveOnlyLruCache<std::string, MoveOnly> cache(2);
+
+    cache.Put("one", MoveOnly(1));
+    cache.Put("one", MoveOnly(101));
+
+    auto one = cache.Get("one");
+    ASSERT_TRUE(one.has_value());
+    EXPECT_EQ(one->get().x_, 101);
+
+    EXPECT_EQ(cache.Size(), 1);
+}
+
+// クリア
+TEST(MoveOnlyLruCacheTest, Clear) {
+    glshaderkit::MoveOnlyLruCache<std::string, MoveOnly> cache(2);
+
+    cache.Put("one", MoveOnly(1));
+    cache.Put("two", MoveOnly(2));
+
+    cache.Clear();
+
+    auto one = cache.Get("one");
+    ASSERT_FALSE(one.has_value());
+
+    auto two = cache.Get("two");
+    ASSERT_FALSE(two.has_value());
+
+    EXPECT_EQ(cache.Size(), 0);
+}
+
+// 要素削除
+TEST(MoveOnlyLruCacheTest, Erase) {
+    glshaderkit::MoveOnlyLruCache<std::string, MoveOnly> cache(2);
+
+    cache.Put("one", MoveOnly(1));
+    cache.Put("two", MoveOnly(2));
+
+    cache.Erase("one");
+
+    auto one = cache.Get("one");
+    ASSERT_FALSE(one.has_value());
+
+    auto two = cache.Get("two");
+    ASSERT_TRUE(two.has_value());
+    EXPECT_EQ(two->get().x_, 2);
+
+    EXPECT_EQ(cache.Size(), 1);
+}

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -1,0 +1,20 @@
+#include <gtest/gtest.h>
+
+#include "config.hpp"
+
+TEST(ConfigTest, DefaultValue) {
+    glshaderkit::Config config;
+    EXPECT_EQ(config.shaderCacheCapacity, 4);
+}
+
+TEST(ConfigTest, Load) {
+    glshaderkit::Config config;
+    config.Load("data/config_load.ini");
+    EXPECT_EQ(config.shaderCacheCapacity, 16);
+}
+
+TEST(ConfigTest, LoadNegative) {
+    glshaderkit::Config config;
+    config.Load("data/config_load_negative.ini");
+    EXPECT_EQ(config.shaderCacheCapacity, 1);
+}

--- a/tests/test_release.cpp
+++ b/tests/test_release.cpp
@@ -1,0 +1,83 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "release.hpp"
+
+using namespace glshaderkit;
+
+class MockRelease : public IRelease {
+public:
+    MOCK_METHOD(void, Release, (), (override));
+};
+
+TEST(ReleaseContainerTest, AddAndContains) {
+    ReleaseContainer container;
+    MockRelease resource1;
+    MockRelease resource2;
+
+    EXPECT_FALSE(container.Contains(&resource1));
+    EXPECT_FALSE(container.Contains(&resource2));
+
+    container.Add(&resource1);
+    EXPECT_TRUE(container.Contains(&resource1));
+    EXPECT_FALSE(container.Contains(&resource2));
+
+    container.Add(&resource2);
+    EXPECT_TRUE(container.Contains(&resource1));
+    EXPECT_TRUE(container.Contains(&resource2));
+}
+
+TEST(ReleaseContainerTest, Size) {
+    ReleaseContainer container;
+    MockRelease resource1;
+    MockRelease resource2;
+
+    EXPECT_EQ(container.Size(), 0);
+
+    container.Add(&resource1);
+    EXPECT_EQ(container.Size(), 1);
+
+    container.Add(&resource2);
+    EXPECT_EQ(container.Size(), 2);
+
+    container.Remove(&resource1);
+    EXPECT_EQ(container.Size(), 1);
+}
+
+TEST(ReleaseContainerTest, Remove) {
+    ReleaseContainer container;
+    MockRelease resource1;
+    MockRelease resource2;
+
+    container.Add(&resource1);
+    container.Add(&resource2);
+
+    container.Remove(&resource1);
+    EXPECT_FALSE(container.Contains(&resource1));
+    EXPECT_TRUE(container.Contains(&resource2));
+
+    container.Remove(&resource1);
+    EXPECT_FALSE(container.Contains(&resource1));
+    EXPECT_TRUE(container.Contains(&resource2));
+}
+
+TEST(ReleaseContainerTest, ReleaseAll) {
+    ReleaseContainer container;
+    testing::StrictMock<MockRelease> resource1;
+    testing::StrictMock<MockRelease> resource2;
+    testing::StrictMock<MockRelease> resource3;
+
+    container.Add(&resource1);
+    container.Add(&resource2);
+    container.Add(&resource3);
+
+    container.Remove(&resource2);
+
+    EXPECT_CALL(resource1, Release()).Times(1);
+    EXPECT_CALL(resource2, Release()).Times(0);
+    EXPECT_CALL(resource3, Release()).Times(1);
+
+    container.ReleaseAll();
+
+    EXPECT_EQ(container.Size(), 0);
+}

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,0 +1,14 @@
+{
+  "default-registry": {
+    "kind": "git",
+    "baseline": "6760f636e7bcd0dd034c5c0906f6174009465c29",
+    "repository": "https://github.com/microsoft/vcpkg"
+  },
+  "registries": [
+    {
+      "kind": "artifact",
+      "location": "https://github.com/microsoft/vcpkg-ce-catalog/archive/refs/heads/main.zip",
+      "name": "microsoft"
+    }
+  ]
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": [
+    "gtest"
+  ]
+}


### PR DESCRIPTION
## 概要

#5 への対応。
drawコールを複数回実行するスクリプトを書きやすくすることを意図してLua側に以下のユーザーデータを提供するようにした。
また、このAPIを使ったスクリプトのサンプルを追加した。

```lua
-- テクスチャ

-- テクスチャオブジェクトの作成 (deactivate時に自動で破棄される)
local texture = GLShaderKit.createTexture(data, w, h)
-- テクスチャをバインドする
texture:bind(unit)
-- テクスチャをアンバインドする
texture:unbind()
-- テクスチャを破棄する
texture:release()

-- フレームバッファ

-- フレームバッファオブジェクトの作成 (deactivate時に自動で破棄される)
local fbo = GLShaderKit.createFrameBuffer(w, h)
-- フレームバッファをバインドする
fbo:bind()
-- フレームバッファをアンバインドする
fbo:unbind()
-- フレームバッファのカラーバッファをテクスチャとしてバインドする
fbo:bindTexture(unit)
-- フレームバッファのカラーバッファの画像データを取得する
fbo:readPixels(data)
-- フレームバッファを破棄する
fbo:release()

-- 頂点

-- 頂点オブジェクトの作成 (deactivate時に自動で破棄される)
-- primitive: "PLANE", "POINTS"
local vao = GLShaderKit.createVertex(primitive, n)
-- 頂点をバインドする
vao:bind()
-- 頂点をアンバインドする
vao:unbind()
-- 描画する
-- vaoとfboは自動でバインドされる
vao:draw(mode, fbo, instanceCount)
-- 頂点を破棄する
vao:release()

-- プログラム (シェーダー)

-- プログラムオブジェクトの作成 (deactivate時に自動で破棄される)
local program = GLShaderKit.CreateProgram(shaderPath, forceReload)
-- プログラムを
program:use()
-- ユニフォーム変数設定 (float, vec2, vec3, vec4)
program:setFloat(name, x, y, z, w)
-- ユニフォーム変数設定 (int, ivec2, ivec3, ivec4)
program:setInt(name, x, y, z, w)
-- ユニフォーム変数設定 (uint, uvec2, uvec3, uvec4)
program:setUInt(name, x, y, z, w)
-- ユニフォーム変数設定 (mat2, mat3, mat4, mat2x3, mat3x2, mat2x4, mat2x4, mat3x4, mat4x3)
program:setMatrix(name, type, transpose, value)
```

## 動作確認

- [x] GLShaderKit_test が通ることを確認した
- [x] example のスクリプトがすべて正常に動作することを確認した