### PR TITLE
オブジェクトの作成を createXXX メソッドから new メソッドに変更

### DIFF
--- a/example/GLShaderKit_gaussianBlur.anm
+++ b/example/GLShaderKit_gaussianBlur.anm
@@ -19,12 +19,12 @@ if GLSK.isInitialized() and amount > 0 then
     -- オブジェクトの画像データ取得
     local data, w, h = obj.getpixeldata()
     -- 画像データからテクスチャ作成
-    local tex = GLSK.createTexture(data, w, h)
+    local tex = GLSK.Texture:new(data, w, h)
     -- フレームバッファオブジェクト作成
-    local srcFbo = GLSK.createFrameBuffer(w, h)
-    local dstFbo = GLSK.createFrameBuffer(w, h)
+    local srcFbo = GLSK.FrameBuffer:new(w, h)
+    local dstFbo = GLSK.FrameBuffer:new(w, h)
     -- 頂点作成
-    local vao = GLSK.createVertex("PLANE", 1)
+    local vao = GLSK.Vertex:new("PLANE", 1)
     -- シェーダープログラムの作成
     GLSK.setShader(shader_path, false)
 

--- a/example/GLShaderKit_multiShader.obj
+++ b/example/GLShaderKit_multiShader.obj
@@ -30,13 +30,13 @@ if GLSK.isInitialized() then
     GLSK.activate()
 
     -- 頂点作成
-    local vao = GLSK.createVertex("PLANE", 1)
+    local vao = GLSK.Vertex:new("PLANE", 1)
     -- フレームバッファオブジェクト作成
-    local fbo1 = GLSK.createFrameBuffer(w, h)
-    local fbo2 = GLSK.createFrameBuffer(w, h)
+    local fbo1 = GLSK.FrameBuffer:new(w, h)
+    local fbo2 = GLSK.FrameBuffer:new(w, h)
     -- シェーダープログラムの作成
-    local program1 = GLSK.createProgram(shader_path_1, false)
-    local program2 = GLSK.createProgram(shader_path_2, false)
+    local program1 = GLSK.Program:new(shader_path_1, false)
+    local program2 = GLSK.Program:new(shader_path_2, false)
 
     -- シェーダー1の実行
     program1:use()

--- a/src/gl_framebuffer.cpp
+++ b/src/gl_framebuffer.cpp
@@ -78,6 +78,11 @@ void GLFramebuffer::Release() {
 namespace lua {
 
 void RegisterFrameBuffer(lua_State* L) {
+    const luaL_Reg staticMethod[] = {
+        {"new", FrameBufferNew},
+        {"unbind", FrameBufferUnbind},
+        {nullptr, nullptr},
+    };
     const luaL_Reg metaMethod[] = {
         {"__gc", FrameBufferMetaGC},
         {nullptr, nullptr},
@@ -91,12 +96,14 @@ void RegisterFrameBuffer(lua_State* L) {
         {nullptr, nullptr},
     };
 
+    RegisterLuaClassTable(L, "FrameBuffer", staticMethod);
     RegisterMetaTable(L, kFrameBufferMetaName, metaMethod, method);
 }
 
-int CreateFrameBuffer(lua_State* L) {
-    int width = luaL_checkinteger(L, 1);
-    int height = luaL_checkinteger(L, 2);
+int FrameBufferNew(lua_State* L) {
+    // 第1引数はクラステーブル
+    int width = luaL_checkinteger(L, 2);
+    int height = luaL_checkinteger(L, 3);
     GLFramebuffer* fbo = new GLFramebuffer(width, height);
     GLContext::Instance().GetReleaseContainer().Add(fbo);
 

--- a/src/gl_framebuffer.hpp
+++ b/src/gl_framebuffer.hpp
@@ -73,7 +73,7 @@ inline GLFramebuffer* GetLuaFrameBuffer(lua_State* L, int index) {
 void RegisterFrameBuffer(lua_State* L);
 
 // FrameBuffer作成
-int CreateFrameBuffer(lua_State* L);
+int FrameBufferNew(lua_State* L);
 
 // ガベージコレクションメタメソッド
 int FrameBufferMetaGC(lua_State* L);

--- a/src/gl_shader.cpp
+++ b/src/gl_shader.cpp
@@ -141,6 +141,10 @@ void GLShader::Release() {
 namespace lua {
 
 void RegisterProgram(lua_State* L) {
+    const luaL_Reg staticMethod[] = {
+        {"new", ProgramNew},
+        {nullptr, nullptr},
+    };
     const luaL_Reg metaMethod[] = {
         {nullptr, nullptr},
     };
@@ -153,12 +157,14 @@ void RegisterProgram(lua_State* L) {
         {nullptr, nullptr},
     };
 
+    RegisterLuaClassTable(L, "Program", staticMethod);
     RegisterMetaTable(L, kProgramMetaName, metaMethod, method);
 }
 
-int CreateProgram(lua_State* L) {
-    const char* path = luaL_checkstring(L, 1);
-    const bool force = lua_toboolean(L, 2);
+int ProgramNew(lua_State* L) {
+    // 第1引数はクラステーブル
+    const char* path = luaL_checkstring(L, 2);
+    const bool force = lua_toboolean(L, 3);
     auto shader = GLContext::Instance().GetShaderManager().CreateProgram(path, force);
 
     GLShader** udata = static_cast<GLShader**>(lua_newuserdata(L, sizeof(GLShader*)));

--- a/src/gl_shader.hpp
+++ b/src/gl_shader.hpp
@@ -58,7 +58,7 @@ inline GLShader* GetLuaProgram(lua_State* L, int index) {
 void RegisterProgram(lua_State* L);
 
 // Program作成
-int CreateProgram(lua_State* L);
+int ProgramNew(lua_State* L);
 
 int ProgramUse(lua_State* L);
 int ProgramSetFloat(lua_State* L);

--- a/src/gl_texture.cpp
+++ b/src/gl_texture.cpp
@@ -63,6 +63,11 @@ void GLTexture::Release() {
 namespace lua {
 
 void RegisterTexture(lua_State* L) {
+    const luaL_Reg staticMethod[] = {
+        {"new", TextureNew},
+        {"unbind", TextureUnbind},
+        {nullptr, nullptr},
+    };
     const luaL_Reg metaMethod[] = {
         {"__gc", TextureMetaGC},
         {nullptr, nullptr},
@@ -74,16 +79,15 @@ void RegisterTexture(lua_State* L) {
         {nullptr, nullptr},
     };
 
+    RegisterLuaClassTable(L, "Texture", staticMethod);
     RegisterMetaTable(L, kTextureMetaName, metaMethod, method);
 }
 
-int CreateTexture(lua_State* L) {
-    if (lua_gettop(L) < 3) {
-        return luaL_error(L, "createTexture()には引数が3個必要です");
-    }
-    void* data = lua_touserdata(L, 1);
-    int width = luaL_checkinteger(L, 2);
-    int height = luaL_checkinteger(L, 3);
+int TextureNew(lua_State* L) {
+    // 第1引数はクラステーブル
+    void* data = lua_touserdata(L, 2);
+    int width = luaL_checkinteger(L, 3);
+    int height = luaL_checkinteger(L, 4);
     GLTexture* tex = new GLTexture(data, width, height);
     GLContext::Instance().GetReleaseContainer().Add(tex);
 

--- a/src/gl_texture.hpp
+++ b/src/gl_texture.hpp
@@ -53,7 +53,7 @@ inline GLTexture* GetLuaTexture(lua_State* L, int index) {
 void RegisterTexture(lua_State* L);
 
 // Texture作成
-int CreateTexture(lua_State* L);
+int TextureNew(lua_State* L);
 
 // ガベージコレクションメタメソッド
 int TextureMetaGC(lua_State* L);

--- a/src/gl_vertex.cpp
+++ b/src/gl_vertex.cpp
@@ -197,6 +197,11 @@ void GLVertex::Release() {
 namespace lua {
 
 void RegisterVertex(lua_State* L) {
+    const luaL_Reg staticMethod[] = {
+        {"new", VertexNew},
+        {"unbind", VertexUnbind},
+        {nullptr, nullptr},
+    };
     const luaL_Reg metaMethod[] = {
         {"__gc", VertexMetaGC},
         {nullptr, nullptr},
@@ -209,17 +214,19 @@ void RegisterVertex(lua_State* L) {
         {nullptr, nullptr},
     };
 
+    RegisterLuaClassTable(L, "Vertex", staticMethod);
     RegisterMetaTable(L, kVertexMetaName, metaMethod, method);
 }
 
-int CreateVertex(lua_State* L) {
+int VertexNew(lua_State* L) {
+    // 第1引数はクラステーブル
     const char* types[] = {"PLANE", "POINTS", nullptr};
     const GLVertex::Primitive primitives[] = {
         GLVertex::Primitive::Plane,
         GLVertex::Primitive::Points,
     };
-    auto primitive = primitives[luaL_checkoption(L, 1, "PLANE", types)];
-    int n = luaL_checkinteger(L, 2);
+    auto primitive = primitives[luaL_checkoption(L, 2, "PLANE", types)];
+    int n = luaL_checkinteger(L, 3);
     GLVertex* vao = new GLVertex(primitive, n);
     GLContext::Instance().GetReleaseContainer().Add(vao);
 

--- a/src/gl_vertex.hpp
+++ b/src/gl_vertex.hpp
@@ -77,7 +77,7 @@ inline GLVertex* GetLuaVertex(lua_State* L, int index) {
 void RegisterVertex(lua_State* L);
 
 // Vertex作成
-int CreateVertex(lua_State* L);
+int VertexNew(lua_State* L);
 
 // ガベージコレクションメタメソッド
 int VertexMetaGC(lua_State* L);

--- a/src/lua_helper.cpp
+++ b/src/lua_helper.cpp
@@ -2,6 +2,12 @@
 
 namespace glshaderkit::lua {
 
+void RegisterLuaClassTable(lua_State* L, const char* name, const luaL_Reg* staticMethod) {
+    lua_newtable(L);
+    luaL_register(L, nullptr, staticMethod);
+    lua_setfield(L, -2, name);
+}
+
 void RegisterMetaTable(
     lua_State* L,
     const char* name,

--- a/src/lua_helper.hpp
+++ b/src/lua_helper.hpp
@@ -7,6 +7,9 @@
 
 namespace glshaderkit::lua {
 
+// スタックトップのテーブルにLuaに新しいクラステーブルを登録する
+void RegisterLuaClassTable(lua_State* L, const char* name, const luaL_Reg* staticMethod);
+
 // Luaに新しいメタテーブルを登録する
 void RegisterMetaTable(
     lua_State* L,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -174,10 +174,6 @@ static const luaL_Reg kLibFunctions[] = {
     {"setUInt", setUInt},
     {"setMatrix", setMatrix},
     {"setTexture2D", setTexture2D},
-    {"createTexture", glshaderkit::lua::CreateTexture},
-    {"createFrameBuffer", glshaderkit::lua::CreateFrameBuffer},
-    {"createVertex", glshaderkit::lua::CreateVertex},
-    {"createProgram", glshaderkit::lua::CreateProgram},
     {nullptr, nullptr},
 };
 
@@ -209,12 +205,6 @@ GL_SHADER_KIT_API int luaopen_GLShaderKit(lua_State* L) {
         context.Release();
     }
 
-    // クラスのメタテーブル登録
-    glshaderkit::lua::RegisterTexture(L);
-    glshaderkit::lua::RegisterFrameBuffer(L);
-    glshaderkit::lua::RegisterVertex(L);
-    glshaderkit::lua::RegisterProgram(L);
-
     // Luaステートが閉じるときにGLコンテキストを解放させる
     void* ud = lua_newuserdata(L, 1);
     if (!ud) {
@@ -228,6 +218,12 @@ GL_SHADER_KIT_API int luaopen_GLShaderKit(lua_State* L) {
 
     // モジュールメソッド登録
     luaL_register(L, "GLShaderKit", kLibFunctions);
+
+    // クラス登録
+    glshaderkit::lua::RegisterTexture(L);
+    glshaderkit::lua::RegisterFrameBuffer(L);
+    glshaderkit::lua::RegisterVertex(L);
+    glshaderkit::lua::RegisterProgram(L);
 
     return 1;
 }


### PR DESCRIPTION
## 概要

Issue #5 の追加対応。
PR #15 でオブジェクト (ユーザーデータ) を作成するためにモジュール直下に `createTexture()` などの関数を追加した。
今後オブジェクト指向なAPIを増やす場合を想定してcreate系メソッドを廃止し、各クラスのテーブルにnewメソッドを追加した。

```lua
-- テクスチャ

-- 変更前
local texture = GLShaderKit.createTexture(data, w, h)
-- 変更後
local texture = GLShaderKit.Texture:new(data, w, h)

-- フレームバッファ

-- 変更前
local fbo = GLShaderKit.createFrameBuffer(w, h)
-- 変更後
local fbo = GLShaderKit.FrameBuffer:new(w, h)

-- 頂点

-- 変更前
local vao = GLShaderKit.createVertex(primitive, n)
-- 変更後
local vao = GLShaderKit.Vertex:new(primitive, n)

-- プログラム (シェーダー)

-- 変更前
local program = GLShaderKit.createProgram(shaderPath, forceReload)
-- 変更後
local program = GLShaderKit.Program:new(shaderPath, forceReload)
```

また、クラステーブルを追加したので `unbind()` も静的メソッドとして呼び出せるようにした。

```lua
GLShaderKit.Texture:unbind()
GLShaderKit.FrameBuffer:unbind()
GLShaderKit.Vertex:unbind()
```

## 動作確認

- [x] GLShaderKit_test が通ることを確認した
- [x] example のスクリプトがすべて正常に動作することを確認した